### PR TITLE
Added an interface Standalone to define sections containing either FailureReport or ConfigurationReport as a standalone.

### DIFF
--- a/core/reporter-api/src/main/java/org/arquillian/reporter/api/event/Standalone.java
+++ b/core/reporter-api/src/main/java/org/arquillian/reporter/api/event/Standalone.java
@@ -1,0 +1,11 @@
+package org.arquillian.reporter.api.event;
+
+/**
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ */
+public interface Standalone {
+
+    static String getStandaloneId(){
+        return Standalone.class + "_section_containing_standalone_report";
+    }
+}

--- a/core/reporter-api/src/main/java/org/arquillian/reporter/api/event/TestClassConfigurationSection.java
+++ b/core/reporter-api/src/main/java/org/arquillian/reporter/api/event/TestClassConfigurationSection.java
@@ -9,7 +9,7 @@ import org.arquillian.reporter.api.model.report.TestClassReport;
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
  */
 public class TestClassConfigurationSection
-    extends SectionEvent<TestClassConfigurationSection, ConfigurationReport, TestClassSection> {
+    extends SectionEvent<TestClassConfigurationSection, ConfigurationReport, TestClassSection> implements Standalone {
 
     private Class<?> testClass;
     private String testSuiteId;
@@ -102,6 +102,78 @@ public class TestClassConfigurationSection
         super(configuration, configurationId);
         this.testClass = testClass;
         this.testSuiteId = testSuiteId;
+    }
+
+    /**
+     * Creates an instance of {@link TestClassConfigurationSection}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     */
+    public static TestClassConfigurationSection standalone() {
+        return new TestClassConfigurationSection(Standalone.getStandaloneId());
+    }
+
+    /**
+     * Creates an instance of {@link TestClassConfigurationSection} with the given test class that is stored to identify a parental section.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     *
+     * @param testClass A test class the {@link ConfigurationReport} belongs to.
+     */
+    public static TestClassConfigurationSection standalone(Class<?> testClass) {
+        return new TestClassConfigurationSection(Standalone.getStandaloneId(), testClass);
+    }
+
+    /**
+     * Creates an instance of {@link TestClassConfigurationSection} with the given test class and test suite that are stored
+     * to identify a parental section.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     *
+     * @param testClass   A test class the {@link ConfigurationReport} belongs to.
+     * @param testSuiteId An id of a test suite the {@link ConfigurationReport} belongs to.
+     */
+    public static TestClassConfigurationSection standalone(Class<?> testClass, String testSuiteId) {
+        return new TestClassConfigurationSection(Standalone.getStandaloneId(), testClass, testSuiteId);
+    }
+
+    /**
+     * Creates an instance of {@link TestClassConfigurationSection} with the given {@link ConfigurationReport}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     *
+     * @param configuration A {@link ConfigurationReport} that should be contained within this {@link TestClassConfigurationSection}
+     */
+    public static TestClassConfigurationSection standalone(ConfigurationReport configuration) {
+        return new TestClassConfigurationSection(configuration, Standalone.getStandaloneId());
+    }
+
+    /**
+     * Creates an instance of {@link TestClassConfigurationSection} with the given {@link ConfigurationReport}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     * The given test class is stored to identify a parental section.
+     *
+     * @param configuration A {@link ConfigurationReport} that should be contained within this {@link TestClassConfigurationSection}
+     * @param testClass     A test class the {@link ConfigurationReport} belongs to.
+     */
+    public static TestClassConfigurationSection standalone(ConfigurationReport configuration, Class<?> testClass) {
+        return new TestClassConfigurationSection(configuration, Standalone.getStandaloneId(), testClass);
+    }
+
+    /**
+     * Creates an instance of {@link TestClassConfigurationSection} with the given {@link ConfigurationReport}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     * The given test class and test suite are stored to identify a parental section.
+     *
+     * @param configuration A {@link ConfigurationReport} that should be contained within this {@link TestClassConfigurationSection}
+     * @param testClass     A test class the {@link ConfigurationReport} belongs to.
+     * @param testSuiteId   An id of a test suite the {@link ConfigurationReport} belongs to.
+     */
+    public static TestClassConfigurationSection standalone(ConfigurationReport configuration, Class<?> testClass,
+        String testSuiteId) {
+        return new TestClassConfigurationSection(configuration, Standalone.getStandaloneId(), testClass, testSuiteId);
     }
 
     @Override

--- a/core/reporter-api/src/main/java/org/arquillian/reporter/api/event/TestMethodConfigurationSection.java
+++ b/core/reporter-api/src/main/java/org/arquillian/reporter/api/event/TestMethodConfigurationSection.java
@@ -11,7 +11,7 @@ import org.arquillian.reporter.api.model.report.TestMethodReport;
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
  */
 public class TestMethodConfigurationSection
-    extends SectionEvent<TestMethodConfigurationSection, ConfigurationReport, TestMethodSection> {
+    extends SectionEvent<TestMethodConfigurationSection, ConfigurationReport, TestMethodSection> implements Standalone {
 
     private Method testMethod;
     private String testSuiteId;
@@ -105,6 +105,83 @@ public class TestMethodConfigurationSection
         super(configuration, configurationId);
         this.testMethod = testMethod;
         this.testSuiteId = testSuiteId;
+    }
+
+    /**
+     * Creates an instance of {@link TestMethodConfigurationSection}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     * The given.
+     */
+    public static TestMethodConfigurationSection standalone() {
+        return new TestMethodConfigurationSection(Standalone.getStandaloneId());
+    }
+
+    /**
+     * Creates an instance of {@link TestMethodConfigurationSection} with the given test method that is stored to identify a parental section.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     * The given.
+     *
+     * @param testMethod A test method the {@link ConfigurationReport} belongs to.
+     */
+    public static TestMethodConfigurationSection standalone(Method testMethod) {
+        return new TestMethodConfigurationSection(Standalone.getStandaloneId(), testMethod);
+    }
+
+    /**
+     * Creates an instance of {@link TestMethodConfigurationSection} with the given test method and test suite id that are stored
+     * to identify a parental section.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     * The given .
+     *
+     * @param testMethod  A test method the {@link ConfigurationReport} belongs to.
+     * @param testSuiteId An id of a test suite the {@link ConfigurationReport} belongs to.
+     */
+    public static TestMethodConfigurationSection standalone(Method testMethod, String testSuiteId) {
+        return new TestMethodConfigurationSection(Standalone.getStandaloneId(), testMethod, testSuiteId);
+    }
+
+    /**
+     * Creates an instance of {@link TestMethodConfigurationSection} with the given {@link ConfigurationReport}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     *
+     * @param configurationReport A {@link ConfigurationReport} that should be contained as the payload of this {@link TestMethodConfigurationSection}
+     */
+    public static TestMethodConfigurationSection standalone(ConfigurationReport configurationReport) {
+        return new TestMethodConfigurationSection(configurationReport, Standalone.getStandaloneId());
+    }
+
+    /**
+     * Creates an instance of {@link TestMethodConfigurationSection} with the given {@link ConfigurationReport}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     * The given test method is stored to identify a parental section.
+     *
+     * @param configurationReport A {@link ConfigurationReport} that should be contained as the payload of this {@link TestMethodConfigurationSection}
+     * @param testMethod          A test method the {@link ConfigurationReport} belongs to.
+     */
+    public static TestMethodConfigurationSection standalone(ConfigurationReport configurationReport,
+        Method testMethod) {
+        return new TestMethodConfigurationSection(configurationReport, Standalone.getStandaloneId(), testMethod);
+    }
+
+    /**
+     * Creates an instance of {@link TestMethodConfigurationSection} with the given {@link ConfigurationReport}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     * The given test method and test suite id are stored to identify a parental section.
+     *
+     * @param configurationReport A {@link ConfigurationReport} that should be contained as the payload of this {@link TestMethodConfigurationSection}
+     * @param testMethod          A test method the {@link ConfigurationReport} belongs to.
+     * @param testSuiteId         An id of a test suite the {@link ConfigurationReport} belongs to.
+     */
+    public static TestMethodConfigurationSection standalone(ConfigurationReport configurationReport, Method testMethod,
+        String testSuiteId) {
+        return new TestMethodConfigurationSection(configurationReport, Standalone.getStandaloneId(), testMethod,
+                                                  testSuiteId);
     }
 
     @Override

--- a/core/reporter-api/src/main/java/org/arquillian/reporter/api/event/TestMethodFailureSection.java
+++ b/core/reporter-api/src/main/java/org/arquillian/reporter/api/event/TestMethodFailureSection.java
@@ -10,7 +10,8 @@ import org.arquillian.reporter.api.model.report.TestMethodReport;
  *
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
  */
-public class TestMethodFailureSection extends SectionEvent<TestMethodFailureSection, FailureReport, TestMethodSection> {
+public class TestMethodFailureSection extends SectionEvent<TestMethodFailureSection, FailureReport, TestMethodSection>
+    implements Standalone {
 
     private Method testMethod;
     private String testSuiteId;
@@ -105,6 +106,81 @@ public class TestMethodFailureSection extends SectionEvent<TestMethodFailureSect
         super(failureReport, failureId);
         this.testMethod = testMethod;
         this.testSuiteId = testSuiteId;
+    }
+
+    /**
+     * Creates an instance of {@link TestMethodFailureSection}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of failure reports no matter what type it is.
+     * The given.
+     */
+    public static TestMethodFailureSection standalone() {
+        return new TestMethodFailureSection(Standalone.getStandaloneId());
+    }
+
+    /**
+     * Creates an instance of {@link TestMethodFailureSection} with the given test method that is stored to identify a parental section.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of failure reports no matter what type it is.
+     * The given.
+     *
+     * @param testMethod    A test method the {@link FailureReport} belongs to.
+     */
+    public static TestMethodFailureSection standalone(Method testMethod) {
+        return new TestMethodFailureSection(Standalone.getStandaloneId(), testMethod);
+    }
+
+    /**
+     * Creates an instance of {@link TestMethodFailureSection} with the given test method and test suite id that are stored
+     * to identify a parental section.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of failure reports no matter what type it is.
+     * The given .
+     *
+     * @param testMethod    A test method the {@link FailureReport} belongs to.
+     * @param testSuiteId   An id of a test suite the {@link FailureReport} belongs to.
+     */
+    public static TestMethodFailureSection standalone(Method testMethod, String testSuiteId) {
+        return new TestMethodFailureSection(Standalone.getStandaloneId(), testMethod, testSuiteId);
+    }
+
+    /**
+     * Creates an instance of {@link TestMethodFailureSection} with the given {@link FailureReport}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of failure reports no matter what type it is.
+     *
+     * @param failureReport A {@link FailureReport} that should be contained as the payload of this {@link TestMethodFailureSection}
+     */
+    public static TestMethodFailureSection standalone(FailureReport failureReport) {
+        return new TestMethodFailureSection(failureReport, Standalone.getStandaloneId());
+    }
+
+    /**
+     * Creates an instance of {@link TestMethodFailureSection} with the given {@link FailureReport}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of failure reports no matter what type it is.
+     * The given test method is stored to identify a parental section.
+     *
+     * @param failureReport A {@link FailureReport} that should be contained as the payload of this {@link TestMethodFailureSection}
+     * @param testMethod    A test method the {@link FailureReport} belongs to.
+     */
+    public static TestMethodFailureSection standalone(FailureReport failureReport, Method testMethod) {
+        return new TestMethodFailureSection(failureReport, Standalone.getStandaloneId(), testMethod);
+    }
+
+    /**
+     * Creates an instance of {@link TestMethodFailureSection} with the given {@link FailureReport}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of failure reports no matter what type it is.
+     * The given test method and test suite id are stored to identify a parental section.
+     *
+     * @param failureReport A {@link FailureReport} that should be contained as the payload of this {@link TestMethodFailureSection}
+     * @param testMethod    A test method the {@link FailureReport} belongs to.
+     * @param testSuiteId   An id of a test suite the {@link FailureReport} belongs to.
+     */
+    public static TestMethodFailureSection standalone(FailureReport failureReport, Method testMethod,
+        String testSuiteId) {
+        return new TestMethodFailureSection(failureReport, Standalone.getStandaloneId(), testMethod, testSuiteId);
     }
 
     @Override

--- a/core/reporter-api/src/main/java/org/arquillian/reporter/api/event/TestSuiteConfigurationSection.java
+++ b/core/reporter-api/src/main/java/org/arquillian/reporter/api/event/TestSuiteConfigurationSection.java
@@ -9,7 +9,7 @@ import org.arquillian.reporter.api.model.report.TestSuiteReport;
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
  */
 public class TestSuiteConfigurationSection
-    extends SectionEvent<TestSuiteConfigurationSection, ConfigurationReport, TestSuiteSection> {
+    extends SectionEvent<TestSuiteConfigurationSection, ConfigurationReport, TestSuiteSection> implements Standalone {
 
     private String testSuiteId;
 
@@ -71,6 +71,51 @@ public class TestSuiteConfigurationSection
         String testSuiteId) {
         super(configuration, configurationId);
         this.testSuiteId = testSuiteId;
+    }
+
+    /**
+     * Creates an instance of {@link TestSuiteConfigurationSection}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     *
+     */
+    public static TestSuiteConfigurationSection standalone() {
+        return new TestSuiteConfigurationSection(Standalone.getStandaloneId());
+    }
+
+    /**
+     * Creates an instance of {@link TestSuiteConfigurationSection} with the given test suite id to identify a parental section.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     *
+     * @param testSuiteId     An id of a test suite the {@link ConfigurationReport} belongs to.
+     */
+    public static TestSuiteConfigurationSection standalone(String testSuiteId) {
+        return new TestSuiteConfigurationSection(Standalone.getStandaloneId(), testSuiteId);
+    }
+
+    /**
+     * Creates an instance of {@link TestSuiteConfigurationSection} with the given {@link ConfigurationReport}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     *
+     * @param configuration   A {@link ConfigurationReport} that should be contained within this {@link TestSuiteConfigurationSection}
+     */
+    public static TestSuiteConfigurationSection standalone(ConfigurationReport configuration) {
+        return new TestSuiteConfigurationSection(configuration, Standalone.getStandaloneId());
+    }
+
+    /**
+     * Creates an instance of {@link TestSuiteConfigurationSection} with the given {@link ConfigurationReport}.
+     * This section is treated as a standalone one which means that it won't be registered in the section tree and the report
+     * won't be merged with any existing one, so it will be added in the list of configuration reports no matter what type it is.
+     * The given test suite id is stored for identifying parental section.
+     *
+     * @param configuration   A {@link ConfigurationReport} that should be contained within this {@link TestSuiteConfigurationSection}
+     * @param testSuiteId     An id of a test suite the {@link ConfigurationReport} belongs to.
+     */
+    public static TestSuiteConfigurationSection standalone(ConfigurationReport configuration, String testSuiteId) {
+        return new TestSuiteConfigurationSection(configuration, Standalone.getStandaloneId(), testSuiteId);
     }
 
     @Override

--- a/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/BasicReport.java
+++ b/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/BasicReport.java
@@ -53,9 +53,10 @@ public class BasicReport extends AbstractReport<BasicReport, BasicReportBuilder>
      * Takes the given {@link Report} and adds it into the list of sub-reports.
      *
      * @param newReport A {@link Report} to be added
+     * @param expectedReportTypeClass A {@link Report} class of a type that is expected as the default one of the given report
      * @return The same instance of {@link Report} that has been added
      */
-    public Report addNewReport(Report newReport) {
+    public Report addNewReport(Report newReport, Class<? extends Report> expectedReportTypeClass) {
         getSubReports().add(newReport);
         return newReport;
     }

--- a/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/ConfigurationReport.java
+++ b/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/ConfigurationReport.java
@@ -58,10 +58,16 @@ public class ConfigurationReport extends AbstractReport<ConfigurationReport, Con
      * Takes the given {@link Report} and adds it into the list of sub-reports.
      *
      * @param newReport A {@link Report} to be added
-     * @return The same instance of {@link Report} that has been added
+     * @param expectedReportTypeClass A {@link Report} class of a type that is expected as the default one of the given report
+     * @return If the given report's type is {@link ConfigurationReport} then it returns the same instance of {@link Report} that has been added; otherwise null.
      */
-    public Report addNewReport(Report newReport) {
+    public Report addNewReport(Report newReport, Class<? extends Report> expectedReportTypeClass) {
         getSubReports().add(newReport);
-        return newReport;
+
+        Class<? extends Report> newReportClass = newReport.getClass();
+        if (ConfigurationReport.class.isAssignableFrom(newReportClass)){
+            return newReport;
+        }
+        return null;
     }
 }

--- a/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/FailureReport.java
+++ b/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/FailureReport.java
@@ -57,10 +57,16 @@ public class FailureReport extends AbstractReport<FailureReport, FailureReportBu
      * Takes the given {@link Report} and adds it into the list of sub-reports.
      *
      * @param newReport A {@link Report} to be added
-     * @return The same instance of {@link Report} that has been added
+     * @param expectedReportTypeClass A {@link Report} class of a type that is expected as the default one of the given report
+     * @return If the given report's type is {@link FailureReport} then it returns the same instance of {@link Report} that has been added; otherwise null.
      */
-    public Report addNewReport(Report newReport) {
+    public Report addNewReport(Report newReport, Class<? extends Report> expectedReportTypeClass) {
         getSubReports().add(newReport);
-        return newReport;
+
+        Class<? extends Report> newReportClass = newReport.getClass();
+        if (FailureReport.class.isAssignableFrom(newReportClass)){
+            return newReport;
+        }
+        return null;
     }
 }

--- a/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/Report.java
+++ b/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/Report.java
@@ -77,11 +77,13 @@ public interface Report<TYPE extends Report, BUILDERTYPE extends ReportBuilder> 
     TYPE merge(TYPE newReport);
 
     /**
-     * Takes the given {@link Report} and adds the whole report into some list of sub-reports contained in this report instance.
+     * Takes the given {@link Report} and based on its type and the type of the given expectedReportTypeClass, it adds
+     * the whole report into some list of sub-reports contained in this report instance.
      *
      * @param newReport A {@link Report} to be added
+     * @param expectedReportTypeClass A {@link Report} class of a type that is expected as the default one of the given report
      * @return The same instance of {@link Report} that has been added into some list of sub-reports.
      */
-    Report addNewReport(Report newReport);
+    Report addNewReport(Report newReport, Class<? extends Report> expectedReportTypeClass);
 
 }

--- a/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/TestClassReport.java
+++ b/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/TestClassReport.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.arquillian.reporter.api.builder.report.TestClassReportBuilder;
-import org.arquillian.reporter.api.utils.ReporterUtils;
 import org.arquillian.reporter.api.model.StringKey;
 import org.arquillian.reporter.api.model.UnknownStringKey;
+import org.arquillian.reporter.api.utils.ReporterUtils;
 
 import static org.arquillian.reporter.api.model.ReporterCoreKey.GENERAL_TEST_CLASS_CONFIGURATION_REPORT;
 
@@ -137,24 +137,23 @@ public class TestClassReport extends AbstractReport<TestClassReport, TestClassRe
     }
 
     /**
-     * Takes the given {@link Report} and:
+     * Takes the given {@link Report} and if the given expectedReportTypeClass:
      * <ul>
-     * <li>if it is a {@link ConfigurationReport} then it adds it into the list of
+     * <li>is a {@link ConfigurationReport} class then it adds it into the list of
      * sub-reports contained in this report's configuration-report.</li>
-     * <li>if it is a {@link TestMethodReport} then it adds it into the list of test-method-reports</li>
-     * <li>if it is any other type of {@link Report} then it adds it into the list of sub-reports</li>
+     * <li>is a {@link TestMethodReport} class then it adds it into the list of test-method-reports</li>
+     * <li>is any other type of {@link Report} class then it adds it into the list of sub-reports</li>
      * </ul>
      *
      * @param newReport A {@link Report} to be added
-     * @return The same instance of {@link Report} that has been added
+     * @param expectedReportTypeClass A {@link Report} class of a type that is expected as the default one of the given report
+     * @return If the report can be tied with section node then, the same instance of {@link Report} that has been added, null otherwise
      */
-    public Report addNewReport(Report newReport) {
-        Class<? extends Report> newReportClass = newReport.getClass();
+    public Report addNewReport(Report newReport, Class<? extends Report> expectedReportTypeClass) {
+        if (expectedReportTypeClass == ConfigurationReport.class) {
+            return getConfiguration().addNewReport(newReport, expectedReportTypeClass);
 
-        if (ConfigurationReport.class.isAssignableFrom(newReportClass)) {
-            return getConfiguration().addNewReport((ConfigurationReport) newReport);
-
-        } else if (TestMethodReport.class.isAssignableFrom(newReportClass)) {
+        } else if (expectedReportTypeClass == TestMethodReport.class) {
             getTestMethodReports().add((TestMethodReport) newReport);
             return newReport;
 

--- a/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/TestMethodReport.java
+++ b/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/TestMethodReport.java
@@ -168,26 +168,25 @@ public class TestMethodReport extends AbstractReport<TestMethodReport, TestMetho
     }
 
     /**
-     * Takes the given {@link Report} and:
+     * Takes the given {@link Report} and if the given expectedReportTypeClass:
      * <ul>
-     * <li>if it is a {@link ConfigurationReport} then it adds it into the list of
+     * <li>is a {@link ConfigurationReport} class then it adds it into the list of
      * sub-reports contained in this report's configuration-report</li>
-     * <li>if it is a {@link FailureReport} then it adds it into the list of
+     * <li>is a {@link FailureReport} class then it adds it into the list of
      * sub-reports contained in this report's failure-report</li>
-     * <li>if it is any other type of {@link Report} then it adds it into the list of sub-reports</li>
+     * <li>is any other type of {@link Report} class then it adds it into the list of sub-reports</li>
      * </ul>
      *
      * @param newReport A {@link Report} to be added
-     * @return The same instance of {@link Report} that has been added
+     * @param expectedReportTypeClass A {@link Report} class of a type that is expected as the default one of the given report
+     * @return If the report can be tied with section node then, the same instance of {@link Report} that has been added, null otherwise
      */
-    public Report addNewReport(Report newReport) {
-        Class<? extends Report> newReportClass = newReport.getClass();
+    public Report addNewReport(Report newReport, Class<? extends Report> expectedReportTypeClass) {
+        if (expectedReportTypeClass == ConfigurationReport.class) {
+            return getConfiguration().addNewReport(newReport, expectedReportTypeClass);
 
-        if (ConfigurationReport.class.isAssignableFrom(newReportClass)) {
-            return getConfiguration().addNewReport((ConfigurationReport) newReport);
-
-        } else if (FailureReport.class.isAssignableFrom(newReportClass)) {
-            return getFailureReport().addNewReport((FailureReport) newReport);
+        } else if (expectedReportTypeClass == FailureReport.class) {
+            return getFailureReport().addNewReport(newReport, expectedReportTypeClass);
 
         } else {
             getSubReports().add(newReport);

--- a/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/TestSuiteReport.java
+++ b/core/reporter-api/src/main/java/org/arquillian/reporter/api/model/report/TestSuiteReport.java
@@ -137,24 +137,23 @@ public class TestSuiteReport extends AbstractReport<TestSuiteReport, TestSuiteRe
     }
 
     /**
-     * Takes the given {@link Report} and:
+     * Takes the given {@link Report} and if the given expectedReportTypeClass:
      * <ul>
-     * <li>if it is a {@link ConfigurationReport} then it adds it into the list of
+     * <li>is a {@link ConfigurationReport} class then it adds it into the list of
      * sub-reports contained in this report's configuration-report.</li>
-     * <li>if it is a {@link TestClassReport} then it adds it into the list of test-class-reports</li>
-     * <li>if it is any other type of {@link Report} then it adds it into the list of sub-reports</li>
+     * <li>is a {@link TestClassReport} class then it adds it into the list of test-class-reports</li>
+     * <li>is any other type of {@link Report} class then it adds it into the list of sub-reports</li>
      * </ul>
      *
      * @param newReport A {@link Report} to be added
-     * @return The same instance of {@link Report} that has been added
+     * @param expectedReportTypeClass A {@link Report} class of a type that is expected as the default one of the given report
+     * @return If the report can be tied with section node then, the same instance of {@link Report} that has been added, null otherwise
      */
-    public Report addNewReport(Report newReport) {
-        Class<? extends Report> newReportClass = newReport.getClass();
+    public Report addNewReport(Report newReport, Class<? extends Report> expectedReportTypeClass) {
+        if (expectedReportTypeClass == ConfigurationReport.class) {
+            return getConfiguration().addNewReport(newReport, expectedReportTypeClass);
 
-        if (ConfigurationReport.class.isAssignableFrom(newReportClass)) {
-            return getConfiguration().addNewReport((ConfigurationReport) newReport);
-
-        } else if (TestClassReport.class.isAssignableFrom(newReportClass)) {
+        } else if (expectedReportTypeClass == TestClassReport.class) {
             getTestClassReports().add((TestClassReport) newReport);
             return newReport;
 

--- a/core/reporter-impl/src/main/java/org/arquillian/reporter/impl/ExecutionReport.java
+++ b/core/reporter-impl/src/main/java/org/arquillian/reporter/impl/ExecutionReport.java
@@ -24,7 +24,7 @@ public class ExecutionReport extends AbstractReport<ExecutionReport, ReportBuild
     public ExecutionReport() {
         super(new UnknownStringKey(EXECUTION_REPORT_NAME));
         this.executionSection = new ExecutionSection(this);
-        sectionTree = new SectionTree(executionSection.identifyYourself(), this);
+        sectionTree = new SectionTree(executionSection.identifyYourself(), this, ExecutionReport.class);
     }
 
     public List<TestSuiteReport> getTestSuiteReports() {
@@ -50,9 +50,8 @@ public class ExecutionReport extends AbstractReport<ExecutionReport, ReportBuild
     }
 
     @Override
-    public Report addNewReport(Report newReport) {
-        Class<? extends Report> newReportClass = newReport.getClass();
-        if (TestSuiteReport.class.isAssignableFrom(newReportClass)) {
+    public Report addNewReport(Report newReport, Class<? extends Report> expectedReportTypeClass) {
+        if (expectedReportTypeClass == TestSuiteReport.class) {
             getTestSuiteReports().add((TestSuiteReport) newReport);
         } else {
             getSubReports().add(newReport);

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/ConfigurationReportTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/ConfigurationReportTest.java
@@ -22,7 +22,7 @@ public class ConfigurationReportTest {
 
         // add a normal report - should be added into List of subReports
         BasicReport basicReport = ReportGeneratorUtils.prepareReport(BasicReport.class, "report", 5, 10);
-        configurationReport.addNewReport(basicReport);
+        configurationReport.addNewReport(basicReport, BasicReport.class);
 
         // verify
         assertThatReport(configurationReport)
@@ -31,7 +31,7 @@ public class ConfigurationReportTest {
 
         // add configuration report - should be added into List of subReports
         ConfigurationReport configToAdd = ReportGeneratorUtils.prepareReport(ConfigurationReport.class, "config", 5, 10);
-        configurationReport.addNewReport(configToAdd);
+        configurationReport.addNewReport(configToAdd, ConfigurationReport.class);
 
         // verify
         assertThatReport(configurationReport)

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/ExecutionReportTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/ExecutionReportTest.java
@@ -29,19 +29,19 @@ public class ExecutionReportTest {
         // add test suite report - should be added into List of test suite reports
         TestSuiteReport firstTestSuiteReportToAdd = ReportGeneratorUtils
             .prepareReport(TestSuiteReport.class, "first", 5, 10);
-        executionReport.addNewReport(firstTestSuiteReportToAdd);
+        executionReport.addNewReport(firstTestSuiteReportToAdd, TestSuiteReport.class);
 
         // add a normal report - should be added into List of subReports
         BasicReport basicReport = ReportGeneratorUtils.prepareReport(BasicReport.class, "report", 5, 10);
-        executionReport.addNewReport(basicReport);
+        executionReport.addNewReport(basicReport, BasicReport.class);
 
         // add another test suite report - should be added into List of test suite reports
         TestSuiteReport secondTestSuiteReportToAdd = ReportGeneratorUtils
             .prepareReport(TestSuiteReport.class, "second", 5, 10);
-        executionReport.addNewReport(secondTestSuiteReportToAdd);
+        executionReport.addNewReport(secondTestSuiteReportToAdd, TestSuiteReport.class);
 
         // add first test suite report for the second time - should be added into List of test suite reports
-        executionReport.addNewReport(firstTestSuiteReportToAdd);
+        executionReport.addNewReport(firstTestSuiteReportToAdd, TestSuiteReport.class);
 
         // verify
         assertThatExecutionReport(executionReport)

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/FailureReportTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/FailureReportTest.java
@@ -21,7 +21,7 @@ public class FailureReportTest {
 
         // add a normal report - should be added into List of subReports
         BasicReport basicReport = ReportGeneratorUtils.prepareReport(BasicReport.class, "report", 5, 10);
-        failureReport.addNewReport(basicReport);
+        failureReport.addNewReport(basicReport, BasicReport.class);
 
         // verify
         assertThatReport(failureReport)
@@ -30,7 +30,7 @@ public class FailureReportTest {
 
         // add failure report - should be added into List of subReports
         FailureReport failureToAdd = ReportGeneratorUtils.prepareReport(FailureReport.class, FAILURE_REPORT_NAME, 5, 10);
-        failureReport.addNewReport(failureToAdd);
+        failureReport.addNewReport(failureToAdd, FailureReport.class);
 
         // verify
         assertThatReport(failureReport)

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/ReportTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/ReportTest.java
@@ -19,7 +19,7 @@ public class ReportTest {
 
         // add a normal report - should be added into List of subReports
         BasicReport basicReport = ReportGeneratorUtils.prepareReport(BasicReport.class, "report", 5, 10);
-        report.addNewReport(basicReport);
+        report.addNewReport(basicReport, BasicReport.class);
 
         // verify
         assertThatReport(report)

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/TestClassReportTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/TestClassReportTest.java
@@ -31,24 +31,24 @@ public class TestClassReportTest {
         ConfigurationReport configurationReportToAdd =
             ReportGeneratorUtils
                 .prepareReport(ConfigurationReport.class, DummyStringKeys.TEST_CLASS_CONFIG_NAME, 5, 10);
-        testClassReport.addNewReport(configurationReportToAdd);
+        testClassReport.addNewReport(configurationReportToAdd, ConfigurationReport.class);
 
         // add test method report - should be added into list of set method reports
         TestMethodReport testMethodReportToAdd = ReportGeneratorUtils
             .prepareReport(TestMethodReport.class, "test method name", 3, 8);
-        testClassReport.addNewReport(testMethodReportToAdd);
+        testClassReport.addNewReport(testMethodReportToAdd, TestMethodReport.class);
 
         // add a normal report - should be added into List of subReports
         BasicReport basicReport = ReportGeneratorUtils.prepareReport(BasicReport.class, "report", 5, 10);
-        testClassReport.addNewReport(basicReport);
+        testClassReport.addNewReport(basicReport, BasicReport.class);
 
         // add test method report - should be added into list of set method reports
         TestMethodReport secondTestMethodReportToAdd =
             ReportGeneratorUtils.prepareReport(TestMethodReport.class, "test method name", 3, 8);
-        testClassReport.addNewReport(secondTestMethodReportToAdd);
+        testClassReport.addNewReport(secondTestMethodReportToAdd, TestMethodReport.class);
 
         // add test method report - should be added into list of set method reports
-        testClassReport.addNewReport(testMethodReportToAdd);
+        testClassReport.addNewReport(testMethodReportToAdd, TestMethodReport.class);
 
         // verify
         assertThatTestClassReport(testClassReport)

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/TestMethodTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/TestMethodTest.java
@@ -30,16 +30,16 @@ public class TestMethodTest {
         // add configuration report - should be added into list of configs
         ConfigurationReport configurationReportToAdd =
             ReportGeneratorUtils.prepareReport(ConfigurationReport.class, "method config", 5, 10);
-        testMethodReport.addNewReport(configurationReportToAdd);
+        testMethodReport.addNewReport(configurationReportToAdd, ConfigurationReport.class);
 
         // add failur method report - should be added into list of failures
         FailureReport failureReportToAdd = ReportGeneratorUtils
             .prepareReport(FailureReport.class, "test method failure", 3, 8);
-        testMethodReport.addNewReport(failureReportToAdd);
+        testMethodReport.addNewReport(failureReportToAdd, FailureReport.class);
 
         // add a normal report - should be added into List of subReports
         BasicReport basicReport = ReportGeneratorUtils.prepareReport(BasicReport.class, "report", 5, 10);
-        testMethodReport.addNewReport(basicReport);
+        testMethodReport.addNewReport(basicReport, BasicReport.class);
 
         // verify
         SoftAssertions.assertSoftly(softly -> {

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/TestSuiteReportTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/TestSuiteReportTest.java
@@ -30,24 +30,24 @@ public class TestSuiteReportTest {
         // add test class report - should be added into List of test class reports
         TestClassReport testClassReportToAdd =
             ReportGeneratorUtils.prepareReport(TestClassReport.class, TEST_CLASS_NAME, 3, 8);
-        testSuiteReport.addNewReport(testClassReportToAdd);
+        testSuiteReport.addNewReport(testClassReportToAdd, TestClassReport.class);
 
         // add configuration report - should be added into list of configs
         ConfigurationReport configurationReportToAdd =
             ReportGeneratorUtils.prepareReport(ConfigurationReport.class, "test suite config", 1, 5);
-        testSuiteReport.addNewReport(configurationReportToAdd);
+        testSuiteReport.addNewReport(configurationReportToAdd, ConfigurationReport.class);
 
         // add a normal report - should be added into List of subReports
         BasicReport basicReport = ReportGeneratorUtils.prepareReport(BasicReport.class, "report", 5, 10);
-        testSuiteReport.addNewReport(basicReport);
+        testSuiteReport.addNewReport(basicReport, BasicReport.class);
 
         // add another test class report - should be added into List of test class reports
         TestClassReport secondTestClassReportToAdd =
             ReportGeneratorUtils.prepareReport(TestClassReport.class, "second test class", 3, 8);
-        testSuiteReport.addNewReport(secondTestClassReportToAdd);
+        testSuiteReport.addNewReport(secondTestClassReportToAdd, TestClassReport.class);
 
         // add first test class report for the second time - should be added into List of test class reports
-        testSuiteReport.addNewReport(testClassReportToAdd);
+        testSuiteReport.addNewReport(testClassReportToAdd, TestClassReport.class);
 
         // verify
         assertThatTestSuiteReport(testSuiteReport)

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/merge/AllSectionTreeMergeTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/merge/AllSectionTreeMergeTest.java
@@ -82,10 +82,10 @@ public class AllSectionTreeMergeTest {
             .prepareReport(reportClass, reportClass.getCanonicalName(), 5, 10);
 
         // create execution section tree that should consume another tree
-        SectionTree originalExecutionTree = new SectionTree<>(executionSectionId, firstExecutionReport);
+        SectionTree originalExecutionTree = new SectionTree<>(executionSectionId, firstExecutionReport, reportClass);
 
         // create execution section tree that should be merged
-        SectionTree executionTreeToMerge = new SectionTree<>(executionSectionId, secondExecutionReport);
+        SectionTree executionTreeToMerge = new SectionTree<>(executionSectionId, secondExecutionReport, reportClass);
 
         // merge
         originalExecutionTree.mergeSectionTree(executionTreeToMerge);


### PR DESCRIPTION
The section is then treated as a standalone one which means that it won't be registered in the section tree and the attached report won't be merged with any existing one, so it will be added into the list of configuration/failure reports, no matter what type it is.
To use standalone section use:
`Reporter.createReport("Config report").add....inSection(TestSuiteConfigurationSection.standalone()).fire(reportEvent);`