### PR TITLE
Now using Interface as method parameter instead of concrete implementation

### DIFF
--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/asserts/ReportAssert.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/asserts/ReportAssert.java
@@ -1,24 +1,24 @@
 package org.arquillian.reporter.impl.asserts;
 
+import org.arquillian.reporter.api.model.StringKey;
+import org.arquillian.reporter.api.model.UnknownStringKey;
+import org.arquillian.reporter.api.model.entry.Entry;
+import org.arquillian.reporter.api.model.entry.KeyValueEntry;
+import org.arquillian.reporter.api.model.report.Report;
+import org.arquillian.reporter.api.model.report.TestClassReport;
+import org.arquillian.reporter.api.model.report.TestMethodReport;
+import org.arquillian.reporter.api.model.report.TestSuiteReport;
+import org.arquillian.reporter.api.model.report.BasicReport;
+import org.arquillian.reporter.api.model.report.AbstractReport;
+import org.arquillian.reporter.impl.ExecutionReport;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.ListAssert;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import org.arquillian.reporter.api.model.AbstractStringKey;
-import org.arquillian.reporter.api.model.UnknownStringKey;
-import org.arquillian.reporter.api.model.entry.Entry;
-import org.arquillian.reporter.api.model.entry.KeyValueEntry;
-import org.arquillian.reporter.api.model.report.AbstractReport;
-import org.arquillian.reporter.api.model.report.BasicReport;
-import org.arquillian.reporter.api.model.report.Report;
-import org.arquillian.reporter.api.model.report.TestClassReport;
-import org.arquillian.reporter.api.model.report.TestMethodReport;
-import org.arquillian.reporter.api.model.report.TestSuiteReport;
-import org.arquillian.reporter.impl.ExecutionReport;
-import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.ListAssert;
 
 import static org.arquillian.reporter.impl.utils.ReportGeneratorUtils.DEFAULT_END_INDEX_FOR_GENERATED_REPORT_PAYLOAD;
 import static org.arquillian.reporter.impl.utils.ReportGeneratorUtils.DEFAULT_START_INDEX_FOR_GENERATED_REPORT_PAYLOAD;
@@ -65,7 +65,7 @@ public class ReportAssert<REPORTASSERTTYPE extends ReportAssert<REPORTASSERTTYPE
 
     }
 
-    public REPORTASSERTTYPE hasName(AbstractStringKey name) {
+    public REPORTASSERTTYPE hasName(StringKey name) {
         isNotNull();
 
         if (!Objects.equals(actual.getName(), name)) {


### PR DESCRIPTION
Changed method 'hasName(AbstractStringKey name) ' to `hasName(StringKey name)`

so we can use it for all classes that are implementing StringKey.