### PR TITLE
ExecutionReport moved to separate class

### DIFF
--- a/core/reporter-impl/src/main/java/org/arquillian/reporter/impl/ExecutionReport.java
+++ b/core/reporter-impl/src/main/java/org/arquillian/reporter/impl/ExecutionReport.java
@@ -10,30 +10,23 @@ import org.arquillian.reporter.api.model.report.Report;
 import org.arquillian.reporter.api.model.report.TestSuiteReport;
 
 /**
- * Report containing all information about the whole test execution
+ * Report containing all reports related to the whole test execution
  *
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
  */
 public class ExecutionReport extends AbstractReport<ExecutionReport, ReportBuilder> {
 
     private final List<TestSuiteReport> testSuiteReports = new ArrayList<>();
-    private final ExecutionSection executionSection;
-    private final SectionTree sectionTree;
     public static final String EXECUTION_REPORT_NAME = "execution";
 
     public ExecutionReport() {
         super(new UnknownStringKey(EXECUTION_REPORT_NAME));
-        this.executionSection = new ExecutionSection(this);
-        sectionTree = new SectionTree(executionSection.identifyYourself(), this, ExecutionReport.class);
     }
 
     public List<TestSuiteReport> getTestSuiteReports() {
         return testSuiteReports;
     }
 
-    public SectionTree getSectionTree() {
-        return sectionTree;
-    }
 
     @Override
     public Class<ReportBuilder> getReportBuilderClass() {
@@ -57,9 +50,5 @@ public class ExecutionReport extends AbstractReport<ExecutionReport, ReportBuild
             getSubReports().add(newReport);
         }
         return newReport;
-    }
-
-    public ExecutionSection getExecutionSection() {
-        return executionSection;
     }
 }

--- a/core/reporter-impl/src/main/java/org/arquillian/reporter/impl/ExecutionStore.java
+++ b/core/reporter-impl/src/main/java/org/arquillian/reporter/impl/ExecutionStore.java
@@ -1,0 +1,31 @@
+package org.arquillian.reporter.impl;
+
+/**
+ * Store containing all information about the whole test execution
+ *
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ */
+public class ExecutionStore {
+
+    private final ExecutionReport executionReport;
+    private final ExecutionSection executionSection;
+    private final SectionTree sectionTree;
+
+    public ExecutionStore() {
+        executionReport = new ExecutionReport();
+        this.executionSection = new ExecutionSection(executionReport);
+        sectionTree = new SectionTree(executionSection.identifyYourself(), executionReport, ExecutionReport.class);
+    }
+
+    public SectionTree getSectionTree() {
+        return sectionTree;
+    }
+
+    public ExecutionSection getExecutionSection() {
+        return executionSection;
+    }
+
+    public ExecutionReport getExecutionReport() {
+        return executionReport;
+    }
+}

--- a/core/reporter-impl/src/main/java/org/arquillian/reporter/impl/SectionEventManager.java
+++ b/core/reporter-impl/src/main/java/org/arquillian/reporter/impl/SectionEventManager.java
@@ -11,7 +11,7 @@ import org.arquillian.reporter.api.model.report.AbstractReport;
 public class SectionEventManager {
 
     public static <SECTIONTYPE extends SectionEvent<SECTIONTYPE, REPORT_TYPE, PARENT_TYPE>, REPORT_TYPE extends AbstractReport, PARENT_TYPE extends SectionEvent>
-    void processEvent(SectionEvent<SECTIONTYPE, REPORT_TYPE, PARENT_TYPE> event, ExecutionReport executionReport) {
+    void processEvent(SectionEvent<SECTIONTYPE, REPORT_TYPE, PARENT_TYPE> event, ExecutionStore executionStore) {
 
         Class<REPORT_TYPE> expectedPayload = event.getReportTypeClass();
         Class<? extends AbstractReport> actualReportClass = event.getReport().getClass();
@@ -33,7 +33,7 @@ public class SectionEventManager {
         // create an expected path in the section tree to the report
         SectionTree eventTree = createTreeRecursively(event, null);
         // and merge the expected path with the current state of section tree
-        executionReport.getSectionTree().mergeSectionTree(eventTree);
+        executionStore.getSectionTree().mergeSectionTree(eventTree);
     }
 
     private static <SECTIONTYPE extends SectionEvent<SECTIONTYPE, REPORT_TYPE, PARENT_TYPE>, REPORT_TYPE extends AbstractReport, PARENT_TYPE extends SectionEvent>

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/asserts/ExecutionReportAssert.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/asserts/ExecutionReportAssert.java
@@ -127,8 +127,4 @@ public class ExecutionReportAssert extends ReportAssert<ExecutionReportAssert, E
                 actual.getName()).isEqualTo(testSuiteReportList);
         return this;
     }
-
-    public SectionTreeAssert sectionTree() {
-        return new SectionTreeAssert(actual.getSectionTree());
-    }
 }

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/event/ReporterLifecycleManagerTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/event/ReporterLifecycleManagerTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.arquillian.reporter.api.builder.BuilderRegistryDelegate;
 import org.arquillian.reporter.api.model.StringKey;
 import org.arquillian.reporter.config.ReporterConfiguration;
-import org.arquillian.reporter.impl.ExecutionReport;
+import org.arquillian.reporter.impl.ExecutionStore;
 import org.arquillian.reporter.impl.base.AbstractReporterTestBase;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -15,6 +15,7 @@ import org.jboss.arquillian.core.api.event.ManagerStopping;
 import org.junit.Test;
 
 import static org.arquillian.reporter.impl.asserts.ExecutionReportAssert.assertThatExecutionReport;
+import static org.arquillian.reporter.impl.asserts.SectionTreeAssert.assertThatSectionTree;
 import static org.mockito.ArgumentMatchers.any;
 /**
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
@@ -22,16 +23,17 @@ import static org.mockito.ArgumentMatchers.any;
 public class ReporterLifecycleManagerTest extends AbstractReporterTestBase {
 
     @Inject
-    private Instance<ExecutionReport> executionReport;
+    private Instance<ExecutionStore> executionStore;
 
     @Test
     public void testWhenManagerIsStartedExecutionReportShouldBeInstantiatedAndFirstObserverInvoked()
         throws IOException {
 
-        assertThatExecutionReport(executionReport.get())
+        assertThatExecutionReport(executionStore.get().getExecutionReport())
             .as("The execution report should be already instantiated")
-            .isNotNull()
-            .sectionTree()
+            .isNotNull();
+
+        assertThatSectionTree(executionStore.get().getSectionTree())
             .as("The execution report should contain instantiated section tree")
             .isNotNull()
             .hasNumberOfSubTrees(0);

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/ExecutionReportTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/model/report/ExecutionReportTest.java
@@ -7,6 +7,7 @@ import org.arquillian.reporter.api.model.report.BasicReport;
 import org.arquillian.reporter.api.model.report.TestSuiteReport;
 import org.arquillian.reporter.impl.ExecutionReport;
 import org.arquillian.reporter.impl.ExecutionSection;
+import org.arquillian.reporter.impl.ExecutionStore;
 import org.arquillian.reporter.impl.utils.ReportGeneratorUtils;
 import org.junit.Test;
 
@@ -57,22 +58,22 @@ public class ExecutionReportTest {
 
     @Test
     public void testNewExecutionReportShouldContainSectionWithTheSameReportItself() {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
-        assertThatSection(executionReport.getExecutionSection())
+        assertThatSection(executionStore.getExecutionSection())
             .hasSectionId(EXECUTION_SECTION_ID)
             .hasReportOfTypeThatIsAssignableFrom(ExecutionReport.class)
-            .hasReportEqualTo(executionReport);
+            .hasReportEqualTo(executionStore.getExecutionReport());
     }
 
     @Test
     public void testNewExecutionReportShouldContainExecutionSectionTree() {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
         Identifier identifier = new Identifier<>(ExecutionSection.class, EXECUTION_SECTION_ID);
 
-        assertThatSectionTree(executionReport.getSectionTree())
+        assertThatSectionTree(executionStore.getSectionTree())
             .hasRootIdentifier(identifier)
-            .hasAssociatedReport(executionReport);
+            .hasAssociatedReport(executionStore.getExecutionReport());
 
     }
 

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/ComplexTreeEventManagerTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/ComplexTreeEventManagerTest.java
@@ -4,10 +4,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.arquillian.reporter.api.event.SectionEvent;
-import org.arquillian.reporter.impl.ExecutionReport;
+import org.arquillian.reporter.impl.ExecutionStore;
 import org.junit.Test;
 
 import static org.arquillian.reporter.impl.asserts.ExecutionReportAssert.assertThatExecutionReport;
+import static org.arquillian.reporter.impl.asserts.SectionTreeAssert.assertThatSectionTree;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.prepareSectionTreeWithReporterCoreSectionsAndReports;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorVerificationHelper.PARENT_COUNT_OF_COMPLEX_PREPARED_TREE;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorVerificationHelper.TREE_NODES_COUNT_OF_COMPLEX_PREPARED_TREE;
@@ -20,16 +21,17 @@ public class ComplexTreeEventManagerTest {
 
     @Test
     public void testAddAllReporterCoreSectionsIntoTreeUsingEventManager() {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
         Map<SectionEvent, List<? extends SectionEvent>> sections =
-            prepareSectionTreeWithReporterCoreSectionsAndReports(executionReport);
+            prepareSectionTreeWithReporterCoreSectionsAndReports(executionStore);
         // verify
         assertThat(sections).hasSize(PARENT_COUNT_OF_COMPLEX_PREPARED_TREE);
 
-        assertThatExecutionReport(executionReport)
-            .reportSubtreeConsistOfGeneratedReports()
-            .sectionTree()
+        assertThatExecutionReport(executionStore.getExecutionReport())
+            .reportSubtreeConsistOfGeneratedReports();
+
+        assertThatSectionTree(executionStore.getSectionTree())
             .wholeTreeConsistOfCouplesMatching(sections)
             .wholeTreeHasNumberOfTreeNodes(TREE_NODES_COUNT_OF_COMPLEX_PREPARED_TREE)
             .associatedReport();

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/TestClassSectionTreeEventManagerTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/TestClassSectionTreeEventManagerTest.java
@@ -8,11 +8,12 @@ import org.arquillian.reporter.api.event.TestSuiteSection;
 import org.arquillian.reporter.api.model.report.ConfigurationReport;
 import org.arquillian.reporter.api.model.report.TestClassReport;
 import org.arquillian.reporter.api.model.report.TestSuiteReport;
-import org.arquillian.reporter.impl.ExecutionReport;
 import org.arquillian.reporter.impl.ExecutionSection;
+import org.arquillian.reporter.impl.ExecutionStore;
 import org.junit.Test;
 
 import static org.arquillian.reporter.impl.asserts.ExecutionReportAssert.assertThatExecutionReport;
+import static org.arquillian.reporter.impl.asserts.SectionTreeAssert.assertThatSectionTree;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.EXPECTED_NUMBER_OF_SECTIONS;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestClassConfigurationSections;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestClassSections;
@@ -27,18 +28,19 @@ public class TestClassSectionTreeEventManagerTest {
 
     @Test
     public void testAddingTestClassSectionsWithReportsUsingEventManager() {
-        ExecutionReport executionReport = new ExecutionReport();
-        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionReport);
+        ExecutionStore executionStore = new ExecutionStore();
+        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
         sections.putAll(
-            feedWithTestClassSections(executionReport, getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
+            feedWithTestClassSections(executionStore, getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
 
         int parentCount = 1 + EXPECTED_NUMBER_OF_SECTIONS;
         int treeNodesCount = parentCount + EXPECTED_NUMBER_OF_SECTIONS;
         assertThat(sections).hasSize(parentCount);
 
-        assertThatExecutionReport(executionReport)
-            .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class)
-            .sectionTree()
+        assertThatExecutionReport(executionStore.getExecutionReport())
+            .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class);
+
+        assertThatSectionTree(executionStore.getSectionTree())
             .wholeTreeConsistOfCouplesMatching(sections)
             .wholeTreeHasNumberOfTreeNodes(treeNodesCount)
             .associatedReport();
@@ -46,22 +48,23 @@ public class TestClassSectionTreeEventManagerTest {
 
     @Test
     public void testAddTestClassConfigurationSectionsWithReportsUsingEventManager() {
-        ExecutionReport executionReport = new ExecutionReport();
-        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionReport);
+        ExecutionStore executionStore = new ExecutionStore();
+        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
         sections.putAll(
-            feedWithTestClassSections(executionReport, getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
+            feedWithTestClassSections(executionStore, getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
         sections.putAll(
-            feedWithTestClassConfigurationSections(executionReport,
+            feedWithTestClassConfigurationSections(executionStore,
                                                    getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
 
         int parentCount = 1 + EXPECTED_NUMBER_OF_SECTIONS * 2;
         int treeNodesCount = (int) (parentCount + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 2));
         assertThat(sections).hasSize(parentCount);
 
-        assertThatExecutionReport(executionReport)
+        assertThatExecutionReport(executionStore.getExecutionReport())
             .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class,
-                                                    ConfigurationReport.class)
-            .sectionTree()
+                                                    ConfigurationReport.class);
+
+        assertThatSectionTree(executionStore.getSectionTree())
             .wholeTreeConsistOfCouplesMatching(sections)
             .wholeTreeHasNumberOfTreeNodes(treeNodesCount)
             .associatedReport();

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/TestMethodSectionTreeEventManagerTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/TestMethodSectionTreeEventManagerTest.java
@@ -11,11 +11,12 @@ import org.arquillian.reporter.api.model.report.FailureReport;
 import org.arquillian.reporter.api.model.report.TestClassReport;
 import org.arquillian.reporter.api.model.report.TestMethodReport;
 import org.arquillian.reporter.api.model.report.TestSuiteReport;
-import org.arquillian.reporter.impl.ExecutionReport;
 import org.arquillian.reporter.impl.ExecutionSection;
+import org.arquillian.reporter.impl.ExecutionStore;
 import org.junit.Test;
 
 import static org.arquillian.reporter.impl.asserts.ExecutionReportAssert.assertThatExecutionReport;
+import static org.arquillian.reporter.impl.asserts.SectionTreeAssert.assertThatSectionTree;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.EXPECTED_NUMBER_OF_SECTIONS;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestClassSections;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestMethodConfigurationSections;
@@ -32,21 +33,22 @@ public class TestMethodSectionTreeEventManagerTest {
 
     @Test
     public void testAddTestMethodSectionsWithReportsUsingEventManager() {
-        ExecutionReport executionReport = new ExecutionReport();
-        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionReport);
+        ExecutionStore executionStore = new ExecutionStore();
+        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
         sections.putAll(
-            feedWithTestClassSections(executionReport, getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
+            feedWithTestClassSections(executionStore, getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
         sections.putAll(
-            feedWithTestMethodSections(executionReport, getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
+            feedWithTestMethodSections(executionStore, getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
 
         int parentCount = (1 + EXPECTED_NUMBER_OF_SECTIONS * 2);
         int treeNodesCount = (int) (parentCount + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 2));
         assertThat(sections).hasSize(parentCount);
 
-        assertThatExecutionReport(executionReport)
+        assertThatExecutionReport(executionStore.getExecutionReport())
             .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class,
-                                                    TestMethodReport.class)
-            .sectionTree()
+                                                    TestMethodReport.class);
+
+        assertThatSectionTree(executionStore.getSectionTree())
             .wholeTreeConsistOfCouplesMatching(sections)
             .wholeTreeHasNumberOfTreeNodes(treeNodesCount)
             .associatedReport();
@@ -54,13 +56,13 @@ public class TestMethodSectionTreeEventManagerTest {
 
     @Test
     public void testAddTestMethodConfigurationSectionsWithReportsUsingEventManager() {
-        ExecutionReport executionReport = new ExecutionReport();
-        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionReport);
-        sections.putAll(feedWithTestClassSections(executionReport,
+        ExecutionStore executionStore = new ExecutionStore();
+        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
+        sections.putAll(feedWithTestClassSections(executionStore,
                                                   getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
-        sections.putAll(feedWithTestMethodSections(executionReport,
+        sections.putAll(feedWithTestMethodSections(executionStore,
                                                    getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
-        sections.putAll(feedWithTestMethodConfigurationSections(executionReport,
+        sections.putAll(feedWithTestMethodConfigurationSections(executionStore,
                                                                 getSubsectionsOfSomeSection(TestClassSection.class,
                                                                                             sections)));
 
@@ -68,10 +70,11 @@ public class TestMethodSectionTreeEventManagerTest {
         int treeNodesCount = (int) (parentCount + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 3));
         assertThat(sections).hasSize(parentCount);
 
-        assertThatExecutionReport(executionReport)
+        assertThatExecutionReport(executionStore.getExecutionReport())
             .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class,
-                                                    TestMethodReport.class, ConfigurationReport.class)
-            .sectionTree()
+                                                    TestMethodReport.class, ConfigurationReport.class);
+
+        assertThatSectionTree(executionStore.getSectionTree())
             .wholeTreeConsistOfCouplesMatching(sections)
             .wholeTreeHasNumberOfTreeNodes(treeNodesCount)
             .associatedReport();
@@ -79,24 +82,26 @@ public class TestMethodSectionTreeEventManagerTest {
 
     @Test
     public void testAddTestMethodFailureSectionsWithReportsUsingEventManager() {
-        ExecutionReport executionReport = new ExecutionReport();
-        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionReport);
-        sections.putAll(feedWithTestClassSections(executionReport,
+        ExecutionStore executionStore = new ExecutionStore();
+        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
+        sections.putAll(feedWithTestClassSections(executionStore,
                                                   getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
-        sections.putAll(feedWithTestMethodSections(executionReport,
+        sections.putAll(feedWithTestMethodSections(executionStore,
                                                    getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
         sections.putAll(
-            feedWithTestMethodFailureSections(executionReport,
+            feedWithTestMethodFailureSections(executionStore,
                                               getSubsectionsOfSomeSection(TestClassSection.class, sections)));
 
         int parentCount = (int) (1 + (EXPECTED_NUMBER_OF_SECTIONS * 2) + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 2));
         int treeNodesCount = (int) (parentCount + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 3));
         assertThat(sections).hasSize(parentCount);
 
-        assertThatExecutionReport(executionReport)
+        assertThatExecutionReport(executionStore.getExecutionReport())
             .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class,
-                                                    TestMethodReport.class, FailureReport.class)
-            .sectionTree().wholeTreeConsistOfCouplesMatching(sections)
+                                                    TestMethodReport.class, FailureReport.class);
+
+        assertThatSectionTree(executionStore.getSectionTree())
+            .wholeTreeConsistOfCouplesMatching(sections)
             .wholeTreeHasNumberOfTreeNodes(treeNodesCount)
             .associatedReport();
     }

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/TestSuiteSectionTreeEventManagerTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/TestSuiteSectionTreeEventManagerTest.java
@@ -6,11 +6,12 @@ import java.util.Map;
 import org.arquillian.reporter.api.event.SectionEvent;
 import org.arquillian.reporter.api.model.report.ConfigurationReport;
 import org.arquillian.reporter.api.model.report.TestSuiteReport;
-import org.arquillian.reporter.impl.ExecutionReport;
 import org.arquillian.reporter.impl.ExecutionSection;
+import org.arquillian.reporter.impl.ExecutionStore;
 import org.junit.Test;
 
 import static org.arquillian.reporter.impl.asserts.ExecutionReportAssert.assertThatExecutionReport;
+import static org.arquillian.reporter.impl.asserts.SectionTreeAssert.assertThatSectionTree;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.EXPECTED_NUMBER_OF_SECTIONS;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestSuiteConfigurationSections;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestSuiteSections;
@@ -24,13 +25,14 @@ public class TestSuiteSectionTreeEventManagerTest {
 
     @Test
     public void testAddingTestSuiteSectionsWithReportsUsingEventManager() {
-        ExecutionReport executionReport = new ExecutionReport();
-        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionReport);
+        ExecutionStore executionStore = new ExecutionStore();
+        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
 
         assertThat(sections).hasSize(1);
-        assertThatExecutionReport(executionReport)
-            .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class)
-            .sectionTree()
+        assertThatExecutionReport(executionStore.getExecutionReport())
+            .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class);
+
+        assertThatSectionTree(executionStore.getSectionTree())
             .wholeTreeConsistOfCouplesMatching(sections)
             .wholeTreeHasNumberOfTreeNodes(1 + EXPECTED_NUMBER_OF_SECTIONS)
             .associatedReport();
@@ -38,18 +40,19 @@ public class TestSuiteSectionTreeEventManagerTest {
 
     @Test
     public void testAddingTestSuiteConfigurationSectionsWithReportsUsingEventManager() {
-        ExecutionReport executionReport = new ExecutionReport();
-        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionReport);
+        ExecutionStore executionStore = new ExecutionStore();
+        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
         sections.putAll(
-            feedWithTestSuiteConfigurationSections(executionReport,
+            feedWithTestSuiteConfigurationSections(executionStore,
                                                    getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
 
         int parentCount = 1 + EXPECTED_NUMBER_OF_SECTIONS;
         int treeNodesCount = (int) (parentCount + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 2));
         assertThat(sections).hasSize(parentCount);
-        assertThatExecutionReport(executionReport)
-            .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, ConfigurationReport.class)
-            .sectionTree()
+        assertThatExecutionReport(executionStore.getExecutionReport())
+            .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, ConfigurationReport.class);
+
+        assertThatSectionTree(executionStore.getSectionTree())
             .wholeTreeConsistOfCouplesMatching(sections)
             .wholeTreeHasNumberOfTreeNodes(treeNodesCount)
             .associatedReport();

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/merge/AbstractMergeTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/merge/AbstractMergeTest.java
@@ -9,13 +9,14 @@ import java.util.Optional;
 import org.arquillian.reporter.api.event.Identifier;
 import org.arquillian.reporter.api.event.SectionEvent;
 import org.arquillian.reporter.api.model.report.Report;
-import org.arquillian.reporter.impl.ExecutionReport;
+import org.arquillian.reporter.impl.ExecutionStore;
 import org.arquillian.reporter.impl.SectionEventManager;
 import org.arquillian.reporter.impl.SectionTree;
 import org.assertj.core.api.SoftAssertions;
 
 import static org.arquillian.reporter.impl.asserts.ExecutionReportAssert.assertThatExecutionReport;
 import static org.arquillian.reporter.impl.asserts.ReportAssert.assertThatReport;
+import static org.arquillian.reporter.impl.asserts.SectionTreeAssert.assertThatSectionTree;
 import static org.arquillian.reporter.impl.utils.ReportGeneratorUtils.prepareReport;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.EXPECTED_NUMBER_OF_SECTIONS;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.prepareSectionTreeWithReporterCoreSectionsAndReports;
@@ -71,12 +72,12 @@ public abstract class AbstractMergeTest {
     protected void verifyMergeSectionUsingIdInComplexTreeUsingEventManager(SectionEvent sectionToMerge,
         String idOfLatestSection, String reportName, int numberOfEntriesAndReports) throws Exception {
 
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
         Map<SectionEvent, List<? extends SectionEvent>> sections =
-            prepareSectionTreeWithReporterCoreSectionsAndReports(executionReport);
+            prepareSectionTreeWithReporterCoreSectionsAndReports(executionStore);
 
-        SectionEventManager.processEvent(sectionToMerge, executionReport);
+        SectionEventManager.processEvent(sectionToMerge, executionStore);
 
         Identifier identifier = null;
         int reportIndex;
@@ -89,7 +90,7 @@ public abstract class AbstractMergeTest {
         }
 
         Optional<SectionTree> merged =
-            getTreeWithIdAndReportNameFromWholeTree(executionReport.getSectionTree(), identifier, reportName);
+            getTreeWithIdAndReportNameFromWholeTree(executionStore.getSectionTree(), identifier, reportName);
 
         assertThat(merged).as("The section-tree-node with identifier: <%s> should be present.", identifier).isPresent();
 
@@ -99,9 +100,10 @@ public abstract class AbstractMergeTest {
             assertThat(merged).isPresent();
             assertThat(sections).hasSize(PARENT_COUNT_OF_COMPLEX_PREPARED_TREE);
 
-            assertThatExecutionReport(executionReport)
-                .reportSubtreeConsistOfGeneratedReports(mergedReports)
-                .sectionTree()
+            assertThatExecutionReport(executionStore.getExecutionReport())
+                .reportSubtreeConsistOfGeneratedReports(mergedReports);
+
+            assertThatSectionTree(executionStore.getSectionTree())
                 .wholeTreeConsistOfCouplesMatching(sections)
                 .wholeTreeHasNumberOfTreeNodes(TREE_NODES_COUNT_OF_COMPLEX_PREPARED_TREE);
 

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/nonexisting/TestClassNonExistingTreeSectionTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/nonexisting/TestClassNonExistingTreeSectionTest.java
@@ -8,7 +8,7 @@ import org.arquillian.reporter.api.event.TestSuiteSection;
 import org.arquillian.reporter.api.model.report.ConfigurationReport;
 import org.arquillian.reporter.api.model.report.TestClassReport;
 import org.arquillian.reporter.api.model.report.TestSuiteReport;
-import org.arquillian.reporter.impl.ExecutionReport;
+import org.arquillian.reporter.impl.ExecutionStore;
 import org.arquillian.reporter.impl.SectionEventManager;
 import org.arquillian.reporter.impl.SectionTree;
 import org.arquillian.reporter.impl.utils.dummy.DummyTestClass;
@@ -28,34 +28,34 @@ public class TestClassNonExistingTreeSectionTest extends AbstractNonExistingTree
 
     @Test
     public void testAddClassToNonExistingSectionInEmptyTreeUsingEventManager() throws Exception {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
         TestClassSection testClassSection = createTestClassSectionInNonExistingSection();
 
-        SectionEventManager.processEvent(testClassSection, executionReport);
+        SectionEventManager.processEvent(testClassSection, executionStore);
 
         TestSuiteReport testSuiteReport =
-            verifyNonExistingSectionAddedAndGetReport(executionReport.getSectionTree(),
+            verifyNonExistingSectionAddedAndGetReport(executionStore.getSectionTree(),
                                                       testClassSection,
-                                                      executionReport.getTestSuiteReports(), 1, 3);
+                                                      executionStore.getExecutionReport().getTestSuiteReports(), 1, 3);
         verifyTestClassReportAddedInNonExistingSection(testSuiteReport.getTestClassReports());
 
     }
 
     @Test
     public void testAddTestClassToNonExistingSectionInNonEmptyTreeUsingEventManager() throws Exception {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
-        prepareSectionTreeWithReporterCoreSectionsAndReports(executionReport);
+        prepareSectionTreeWithReporterCoreSectionsAndReports(executionStore);
 
         TestClassSection testClassSection = createTestClassSectionInNonExistingSection();
 
-        SectionEventManager.processEvent(testClassSection, executionReport);
+        SectionEventManager.processEvent(testClassSection, executionStore);
 
         TestSuiteReport testSuiteReport =
-            verifyNonExistingSectionAddedAndGetReport(executionReport.getSectionTree(),
+            verifyNonExistingSectionAddedAndGetReport(executionStore.getSectionTree(),
                                                       testClassSection,
-                                                      executionReport.getTestSuiteReports(),
+                                                      executionStore.getExecutionReport().getTestSuiteReports(),
                                                       EXPECTED_NUMBER_OF_SECTIONS + 1,
                                                       TREE_NODES_COUNT_OF_COMPLEX_PREPARED_TREE + 2);
         verifyTestClassReportAddedInNonExistingSection(testSuiteReport.getTestClassReports());
@@ -64,14 +64,14 @@ public class TestClassNonExistingTreeSectionTest extends AbstractNonExistingTree
 
     @Test
     public void testAddTestClassConfigurationToNonExistingSectionInEmptyTreeUsingEventManager() throws Exception {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
         TestClassConfigurationSection testClassConfigSection = createTestClassConfigSectionInNonExistingSection();
 
-        SectionEventManager.processEvent(testClassConfigSection, executionReport);
+        SectionEventManager.processEvent(testClassConfigSection, executionStore);
 
         SectionTree<TestSuiteSection, TestSuiteReport> suiteTree =
-            verifyNonExistingSuiteSectionAddedAndGetTree(executionReport.getSectionTree(),
+            verifyNonExistingSuiteSectionAddedAndGetTree(executionStore.getSectionTree(),
                                                          new TestClassSection(SecondDummyTestClass.class),
                                                          1, 4);
 
@@ -87,16 +87,16 @@ public class TestClassNonExistingTreeSectionTest extends AbstractNonExistingTree
 
     @Test
     public void testAddTestClassConfigurationToNonExistingSectionInNonEmptyTreeUsingEventManager() throws Exception {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
-        prepareSectionTreeWithReporterCoreSectionsAndReports(executionReport);
+        prepareSectionTreeWithReporterCoreSectionsAndReports(executionStore);
 
         TestClassConfigurationSection testClassConfigSection = createTestClassConfigSectionInNonExistingSection();
 
-        SectionEventManager.processEvent(testClassConfigSection, executionReport);
+        SectionEventManager.processEvent(testClassConfigSection, executionStore);
 
         SectionTree<TestSuiteSection, TestSuiteReport> suiteTree =
-            verifyNonExistingSuiteSectionAddedAndGetTree(executionReport.getSectionTree(),
+            verifyNonExistingSuiteSectionAddedAndGetTree(executionStore.getSectionTree(),
                                                          new TestClassSection(SecondDummyTestClass.class),
                                                          EXPECTED_NUMBER_OF_SECTIONS + 1,
                                                          TREE_NODES_COUNT_OF_COMPLEX_PREPARED_TREE + 3);

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/nonexisting/TestMethodNonExistingTreeSectionTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/nonexisting/TestMethodNonExistingTreeSectionTest.java
@@ -13,7 +13,7 @@ import org.arquillian.reporter.api.model.report.FailureReport;
 import org.arquillian.reporter.api.model.report.TestClassReport;
 import org.arquillian.reporter.api.model.report.TestMethodReport;
 import org.arquillian.reporter.api.model.report.TestSuiteReport;
-import org.arquillian.reporter.impl.ExecutionReport;
+import org.arquillian.reporter.impl.ExecutionStore;
 import org.arquillian.reporter.impl.SectionEventManager;
 import org.arquillian.reporter.impl.SectionTree;
 import org.arquillian.reporter.impl.utils.dummy.SecondDummyTestClass;
@@ -33,14 +33,14 @@ public class TestMethodNonExistingTreeSectionTest extends AbstractNonExistingTre
 
     @Test
     public void testAddMethodToNonExistingSectionInEmptyTreeUsingEventManager() throws Exception {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
         TestMethodSection methodSection = createTestMethodSectionInNonExistingSection();
 
-        SectionEventManager.processEvent(methodSection, executionReport);
+        SectionEventManager.processEvent(methodSection, executionStore);
 
         SectionTree<TestSuiteSection, TestSuiteReport> suiteTree =
-            verifyNonExistingSuiteSectionAddedAndGetTree(executionReport.getSectionTree(),
+            verifyNonExistingSuiteSectionAddedAndGetTree(executionStore.getSectionTree(),
                                                          new TestClassSection(SecondDummyTestClass.class),
                                                          1, 4);
 
@@ -56,15 +56,15 @@ public class TestMethodNonExistingTreeSectionTest extends AbstractNonExistingTre
 
     @Test
     public void testAddTestMethodToNonExistingSectionInNonEmptyTreeUsingEventManager() throws Exception {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
-        prepareSectionTreeWithReporterCoreSectionsAndReports(executionReport);
+        prepareSectionTreeWithReporterCoreSectionsAndReports(executionStore);
 
         TestMethodSection methodSection = createTestMethodSectionInNonExistingSection();
-        SectionEventManager.processEvent(methodSection, executionReport);
+        SectionEventManager.processEvent(methodSection, executionStore);
 
         SectionTree<TestSuiteSection, TestSuiteReport> suiteTree =
-            verifyNonExistingSuiteSectionAddedAndGetTree(executionReport.getSectionTree(),
+            verifyNonExistingSuiteSectionAddedAndGetTree(executionStore.getSectionTree(),
                                                          new TestClassSection(SecondDummyTestClass.class),
                                                          EXPECTED_NUMBER_OF_SECTIONS + 1,
                                                          TREE_NODES_COUNT_OF_COMPLEX_PREPARED_TREE + 3);
@@ -80,14 +80,14 @@ public class TestMethodNonExistingTreeSectionTest extends AbstractNonExistingTre
 
     @Test
     public void testAddTestMethodConfigurationToNonExistingSectionInEmptyTreeUsingEventManager() throws Exception {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
         TestMethodConfigurationSection methodConfigSection = createTestMethodConfigSectionInNonExistingSection();
 
-        SectionEventManager.processEvent(methodConfigSection, executionReport);
+        SectionEventManager.processEvent(methodConfigSection, executionStore);
 
         SectionTree<TestSuiteSection, TestSuiteReport> suiteTree =
-            verifyNonExistingSuiteSectionAddedAndGetTree(executionReport.getSectionTree(),
+            verifyNonExistingSuiteSectionAddedAndGetTree(executionStore.getSectionTree(),
                                                          new TestClassSection(SecondDummyTestClass.class),
                                                          1, 5);
 
@@ -107,14 +107,14 @@ public class TestMethodNonExistingTreeSectionTest extends AbstractNonExistingTre
 
     @Test
     public void testAddTestMethodConfigurationToNonExistingSectionInNonEmptyTreeUsingEventManager() throws Exception {
-        ExecutionReport executionReport = new ExecutionReport();
-        prepareSectionTreeWithReporterCoreSectionsAndReports(executionReport);
+        ExecutionStore executionStore = new ExecutionStore();
+        prepareSectionTreeWithReporterCoreSectionsAndReports(executionStore);
 
         TestMethodConfigurationSection methodConfigSection = createTestMethodConfigSectionInNonExistingSection();
-        SectionEventManager.processEvent(methodConfigSection, executionReport);
+        SectionEventManager.processEvent(methodConfigSection, executionStore);
 
         SectionTree<TestSuiteSection, TestSuiteReport> suiteTree =
-            verifyNonExistingSuiteSectionAddedAndGetTree(executionReport.getSectionTree(),
+            verifyNonExistingSuiteSectionAddedAndGetTree(executionStore.getSectionTree(),
                                                          new TestClassSection(SecondDummyTestClass.class),
                                                          EXPECTED_NUMBER_OF_SECTIONS + 1,
                                                          TREE_NODES_COUNT_OF_COMPLEX_PREPARED_TREE + 4);
@@ -135,14 +135,14 @@ public class TestMethodNonExistingTreeSectionTest extends AbstractNonExistingTre
 
     @Test
     public void testAddTestMethodFailureToNonExistingSectionInEmptyTreeUsingEventManager() throws Exception {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
         TestMethodFailureSection methodFailureSection = createTestMethodFailureSectionInNonExistingSection();
 
-        SectionEventManager.processEvent(methodFailureSection, executionReport);
+        SectionEventManager.processEvent(methodFailureSection, executionStore);
 
         SectionTree<TestSuiteSection, TestSuiteReport> suiteTree =
-            verifyNonExistingSuiteSectionAddedAndGetTree(executionReport.getSectionTree(),
+            verifyNonExistingSuiteSectionAddedAndGetTree(executionStore.getSectionTree(),
                                                          new TestClassSection(SecondDummyTestClass.class),
                                                          1, 5);
 
@@ -162,14 +162,14 @@ public class TestMethodNonExistingTreeSectionTest extends AbstractNonExistingTre
 
     @Test
     public void testAddTestMethodFailureToNonExistingSectionInNonEmptyTreeUsingEventManager() throws Exception {
-        ExecutionReport executionReport = new ExecutionReport();
-        prepareSectionTreeWithReporterCoreSectionsAndReports(executionReport);
+        ExecutionStore executionStore = new ExecutionStore();
+        prepareSectionTreeWithReporterCoreSectionsAndReports(executionStore);
 
         TestMethodFailureSection methodFailureSection = createTestMethodFailureSectionInNonExistingSection();
-        SectionEventManager.processEvent(methodFailureSection, executionReport);
+        SectionEventManager.processEvent(methodFailureSection, executionStore);
 
         SectionTree<TestSuiteSection, TestSuiteReport> suiteTree =
-            verifyNonExistingSuiteSectionAddedAndGetTree(executionReport.getSectionTree(),
+            verifyNonExistingSuiteSectionAddedAndGetTree(executionStore.getSectionTree(),
                                                          new TestClassSection(SecondDummyTestClass.class),
                                                          EXPECTED_NUMBER_OF_SECTIONS + 1,
                                                          TREE_NODES_COUNT_OF_COMPLEX_PREPARED_TREE + 4);

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/nonexisting/TestSuiteNonExistingTreeSectionTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/nonexisting/TestSuiteNonExistingTreeSectionTest.java
@@ -3,7 +3,7 @@ package org.arquillian.reporter.impl.section.nonexisting;
 import org.arquillian.reporter.api.event.TestSuiteConfigurationSection;
 import org.arquillian.reporter.api.model.report.ConfigurationReport;
 import org.arquillian.reporter.api.model.report.TestSuiteReport;
-import org.arquillian.reporter.impl.ExecutionReport;
+import org.arquillian.reporter.impl.ExecutionStore;
 import org.arquillian.reporter.impl.SectionEventManager;
 import org.junit.Test;
 
@@ -18,33 +18,33 @@ public class TestSuiteNonExistingTreeSectionTest extends AbstractNonExistingTree
 
     @Test
     public void testAddTestSuiteConfigurationToNonExistingSectionInEmptyTreeUsingEventManager() throws Exception {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
         TestSuiteConfigurationSection testSuiteConfigSection = createTestSuiteConfigSectionInNonExistingSection();
 
-        SectionEventManager.processEvent(testSuiteConfigSection, executionReport);
+        SectionEventManager.processEvent(testSuiteConfigSection, executionStore);
 
         TestSuiteReport testSuiteReport =
-            verifyNonExistingSectionAddedAndGetReport(executionReport.getSectionTree(), testSuiteConfigSection,
-                                                      executionReport.getTestSuiteReports(), 1, 3);
+            verifyNonExistingSectionAddedAndGetReport(executionStore.getSectionTree(), testSuiteConfigSection,
+                                                      executionStore.getExecutionReport().getTestSuiteReports(), 1, 3);
         verifyConfigAddedInNonExistingSection(testSuiteReport.getConfiguration());
 
     }
 
     @Test
     public void testAddTestSuiteConfigurationToNonExistingSectionInNonEmptyTreeUsingEventManager() throws Exception {
-        ExecutionReport executionReport = new ExecutionReport();
+        ExecutionStore executionStore = new ExecutionStore();
 
-        prepareSectionTreeWithReporterCoreSectionsAndReports(executionReport);
+        prepareSectionTreeWithReporterCoreSectionsAndReports(executionStore);
 
         TestSuiteConfigurationSection testSuiteConfigSection = createTestSuiteConfigSectionInNonExistingSection();
 
-        SectionEventManager.processEvent(testSuiteConfigSection, executionReport);
+        SectionEventManager.processEvent(testSuiteConfigSection, executionStore);
 
         TestSuiteReport testSuiteReport =
-            verifyNonExistingSectionAddedAndGetReport(executionReport.getSectionTree(),
+            verifyNonExistingSectionAddedAndGetReport(executionStore.getSectionTree(),
                                                       testSuiteConfigSection,
-                                                      executionReport.getTestSuiteReports(),
+                                                      executionStore.getExecutionReport().getTestSuiteReports(),
                                                       EXPECTED_NUMBER_OF_SECTIONS + 1,
                                                       TREE_NODES_COUNT_OF_COMPLEX_PREPARED_TREE + 2);
 

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/utils/SectionGeneratorUtils.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/utils/SectionGeneratorUtils.java
@@ -22,8 +22,8 @@ import org.arquillian.reporter.api.model.report.Report;
 import org.arquillian.reporter.api.model.report.TestClassReport;
 import org.arquillian.reporter.api.model.report.TestMethodReport;
 import org.arquillian.reporter.api.model.report.TestSuiteReport;
-import org.arquillian.reporter.impl.ExecutionReport;
 import org.arquillian.reporter.impl.ExecutionSection;
+import org.arquillian.reporter.impl.ExecutionStore;
 import org.arquillian.reporter.impl.SectionEventManager;
 import org.arquillian.reporter.impl.utils.dummy.DummyTestClass;
 
@@ -115,7 +115,7 @@ public class SectionGeneratorUtils {
     // methods for feeding execution report
 
     public static Map<SectionEvent, List<? extends SectionEvent>> feedWithTestSuiteSections(
-        ExecutionReport executionReport) {
+        ExecutionStore executionStore) {
 
         Map<SectionEvent, List<? extends SectionEvent>> sections = new HashMap<>();
         List<TestSuiteSection> testSuiteSections =
@@ -128,14 +128,14 @@ public class SectionGeneratorUtils {
                                       index + 10),
                         getTestSuiteSectionName(index));
                 }
-            }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionReport);
+            }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionStore);
 
-        sections.put(executionReport.getExecutionSection(), testSuiteSections);
+        sections.put(executionStore.getExecutionSection(), testSuiteSections);
         return sections;
     }
 
     public static Map<SectionEvent, List<? extends SectionEvent>> feedWithTestSuiteConfigurationSections(
-        ExecutionReport executionReport, List<SectionEvent> parentTestSuiteSections) {
+        ExecutionStore executionStore, List<SectionEvent> parentTestSuiteSections) {
 
         Map<SectionEvent, List<? extends SectionEvent>> sections = new HashMap<>();
 
@@ -153,7 +153,7 @@ public class SectionGeneratorUtils {
                             getTestSuiteConfigSectionName(index),
                             suiteId);
                     }
-                }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionReport);
+                }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionStore);
             sections.put((TestSuiteSection) suite, testSuiteConfigSections);
         });
 
@@ -161,7 +161,7 @@ public class SectionGeneratorUtils {
     }
 
     public static Map<SectionEvent, List<? extends SectionEvent>> feedWithTestClassSections(
-        ExecutionReport executionReport, List<SectionEvent> parentTestSuiteSections) {
+        ExecutionStore executionStore, List<SectionEvent> parentTestSuiteSections) {
 
         Map<SectionEvent, List<? extends SectionEvent>> sections = new HashMap<>();
 
@@ -181,7 +181,7 @@ public class SectionGeneratorUtils {
                             DummyTestClass.class,
                             suiteId);
                     }
-                }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionReport);
+                }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionStore);
             // add only one test-class section as it is processed using same class, all of them should be merged info one report
             sections.put((TestSuiteSection) suite, testClassSections.subList(0, 1));
         });
@@ -190,7 +190,7 @@ public class SectionGeneratorUtils {
     }
 
     public static Map<SectionEvent, List<? extends SectionEvent>> feedWithTestClassConfigurationSections(
-        ExecutionReport executionReport, List<SectionEvent> parentTestClassSections) {
+        ExecutionStore executionStore, List<SectionEvent> parentTestClassSections) {
 
         Map<SectionEvent, List<? extends SectionEvent>> sections = new HashMap<>();
 
@@ -214,14 +214,14 @@ public class SectionGeneratorUtils {
                              testClassConfigurationSection.setTestSuiteId(testSuiteId);
                              return testClassConfigurationSection;
                          }
-                     }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionReport));
+                     }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionStore));
         });
 
         return sections;
     }
 
     public static Map<SectionEvent, List<? extends SectionEvent>> feedWithTestMethodSections(
-        ExecutionReport executionReport, List<SectionEvent> parentTestClassSections) {
+        ExecutionStore executionStore, List<SectionEvent> parentTestClassSections) {
 
         Map<SectionEvent, List<? extends SectionEvent>> sections = new HashMap<>();
 
@@ -241,14 +241,14 @@ public class SectionGeneratorUtils {
                                  testMethodSection.setTestSuiteId(testSuiteId);
                                  return testMethodSection;
                              }
-                         }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionReport));
+                         }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionStore));
         });
 
         return sections;
     }
 
     public static Map<SectionEvent, List<? extends SectionEvent>> feedWithTestMethodConfigurationSections(
-        ExecutionReport executionReport, List<SectionEvent> parentTestMethodSections) {
+        ExecutionStore executionStore, List<SectionEvent> parentTestMethodSections) {
 
         Map<SectionEvent, List<? extends SectionEvent>> sections = new HashMap<>();
 
@@ -272,14 +272,14 @@ public class SectionGeneratorUtils {
                                  testMethodConfigSection.setTestSuiteId(testSuiteId);
                                  return testMethodConfigSection;
                              }
-                         }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionReport));
+                         }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionStore));
         });
 
         return sections;
     }
 
     public static Map<SectionEvent, List<? extends SectionEvent>> feedWithTestMethodFailureSections(
-        ExecutionReport executionReport, List<SectionEvent> parentTestMethodSections) {
+        ExecutionStore executionStore, List<SectionEvent> parentTestMethodSections) {
 
         Map<SectionEvent, List<? extends SectionEvent>> sections = new HashMap<>();
 
@@ -303,36 +303,36 @@ public class SectionGeneratorUtils {
                                  testMethodFailureSection.setTestSuiteId(testSuiteId);
                                  return testMethodFailureSection;
                              }
-                         }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionReport));
+                         }.generateSetOfSections(EXPECTED_NUMBER_OF_SECTIONS, executionStore));
         });
 
         return sections;
     }
 
     public static Map<SectionEvent, List<? extends SectionEvent>> prepareSectionTreeWithReporterCoreSectionsAndReports(
-        ExecutionReport executionReport) {
+        ExecutionStore executionStore) {
         // add test suite sections
-        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionReport);
+        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
         List<SectionEvent> testSuiteSubsections = getSubsectionsOfSomeSection(ExecutionSection.class, sections);
 
         // add test class sections
-        sections.putAll(feedWithTestClassSections(executionReport, testSuiteSubsections));
+        sections.putAll(feedWithTestClassSections(executionStore, testSuiteSubsections));
         List<SectionEvent> testClassSubsections = getSubsectionsOfSomeSection(TestSuiteSection.class, sections);
 
         // add test method sections
-        sections.putAll(feedWithTestMethodSections(executionReport, testClassSubsections));
+        sections.putAll(feedWithTestMethodSections(executionStore, testClassSubsections));
         List<SectionEvent> testMethodSubsections = getSubsectionsOfSomeSection(TestClassSection.class, sections);
 
         // add test class config sections
-        mergeMapOfSections(sections, feedWithTestClassConfigurationSections(executionReport, testClassSubsections));
+        mergeMapOfSections(sections, feedWithTestClassConfigurationSections(executionStore, testClassSubsections));
 
         // add test suite config sections
-        mergeMapOfSections(sections, feedWithTestSuiteConfigurationSections(executionReport, testSuiteSubsections));
+        mergeMapOfSections(sections, feedWithTestSuiteConfigurationSections(executionStore, testSuiteSubsections));
 
         // add test method failure sections
-        mergeMapOfSections(sections, feedWithTestMethodFailureSections(executionReport, testMethodSubsections));
+        mergeMapOfSections(sections, feedWithTestMethodFailureSections(executionStore, testMethodSubsections));
         // add test method config sections
-        mergeMapOfSections(sections, feedWithTestMethodConfigurationSections(executionReport, testMethodSubsections));
+        mergeMapOfSections(sections, feedWithTestMethodConfigurationSections(executionStore, testMethodSubsections));
 
         return sections;
     }
@@ -362,13 +362,13 @@ public class SectionGeneratorUtils {
 
     abstract static class SectionGeneratorAndProcessor<T extends SectionEvent> {
 
-        List<T> generateSetOfSections(int number, ExecutionReport executionReport) {
+        List<T> generateSetOfSections(int number, ExecutionStore executionStore) {
             return IntStream
                 .range(0, number)
                 .mapToObj(index -> {
                               try {
                                   T sectionInstance = createNewInstance(index);
-                                  SectionEventManager.processEvent(sectionInstance, executionReport);
+                                  SectionEventManager.processEvent(sectionInstance, executionStore);
                                   return sectionInstance;
                               } catch (Exception e) {
                                   throw new RuntimeException(e);


### PR DESCRIPTION
ExecutionReport moved to separate class and introduced ExecutionStore that keeps all information (tree, section, report) related to the whole
execution.
two benefits:
* now, I can pass the whole ExecutionReport class to Gson to generate JSON report (not list of TestSuite) so we are able to add information (subreports/entries) to the execution report and resulting JSON won't contain an array at the root level
* we keep the execution report separate from trees and section