### PR TITLE
Raised Java heap size to 2048 using maven-surefire-plugin

### DIFF
--- a/core/reporter-impl/pom.xml
+++ b/core/reporter-impl/pom.xml
@@ -83,7 +83,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
@@ -92,6 +91,12 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Xmx2048m</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The reason is that several times the travis build failed because JVM had
crashed - probably the tests require more memory than is available on travis by default