### PR TITLE
Adds test for standalone section.

### DIFF
--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/TestClassSectionTreeEventManagerTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/TestClassSectionTreeEventManagerTest.java
@@ -2,23 +2,28 @@ package org.arquillian.reporter.impl.section;
 
 import java.util.List;
 import java.util.Map;
-
 import org.arquillian.reporter.api.event.SectionEvent;
+import org.arquillian.reporter.api.event.TestClassConfigurationSection;
 import org.arquillian.reporter.api.event.TestSuiteSection;
 import org.arquillian.reporter.api.model.report.ConfigurationReport;
+import org.arquillian.reporter.api.model.report.Report;
 import org.arquillian.reporter.api.model.report.TestClassReport;
 import org.arquillian.reporter.api.model.report.TestSuiteReport;
 import org.arquillian.reporter.impl.ExecutionSection;
 import org.arquillian.reporter.impl.ExecutionStore;
+import org.arquillian.reporter.impl.SectionEventManager;
+import org.arquillian.reporter.impl.utils.ReportGeneratorUtils;
 import org.junit.Test;
 
 import static org.arquillian.reporter.impl.asserts.ExecutionReportAssert.assertThatExecutionReport;
+import static org.arquillian.reporter.impl.asserts.ReportAssert.assertThatReport;
 import static org.arquillian.reporter.impl.asserts.SectionTreeAssert.assertThatSectionTree;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.EXPECTED_NUMBER_OF_SECTIONS;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestClassConfigurationSections;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestClassSections;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestSuiteSections;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.getSubsectionsOfSomeSection;
+import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.getTestSuiteSectionName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -54,7 +59,7 @@ public class TestClassSectionTreeEventManagerTest {
             feedWithTestClassSections(executionStore, getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
         sections.putAll(
             feedWithTestClassConfigurationSections(executionStore,
-                                                   getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
+                getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
 
         int parentCount = 1 + EXPECTED_NUMBER_OF_SECTIONS * 2;
         int treeNodesCount = (int) (parentCount + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 2));
@@ -62,7 +67,7 @@ public class TestClassSectionTreeEventManagerTest {
 
         assertThatExecutionReport(executionStore.getExecutionReport())
             .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class,
-                                                    ConfigurationReport.class);
+                ConfigurationReport.class);
 
         assertThatSectionTree(executionStore.getSectionTree())
             .wholeTreeConsistOfCouplesMatching(sections)
@@ -70,4 +75,44 @@ public class TestClassSectionTreeEventManagerTest {
             .associatedReport();
     }
 
+    @Test
+    public void testAddingStandaloneTestClassConfigurationSectionsWithReportsUsingEventManager() throws Exception {
+        ExecutionStore executionStore = new ExecutionStore();
+        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
+        sections.putAll(
+            feedWithTestClassSections(executionStore, getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
+        sections.putAll(
+            feedWithTestClassConfigurationSections(executionStore,
+                getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
+
+        ConfigurationReport configurationReport =
+            ReportGeneratorUtils.prepareReport(ConfigurationReport.class, "Standalone config report", 0, 10);
+
+        TestClassConfigurationSection standaloneTestClassConfig = TestClassConfigurationSection
+            .standalone(configurationReport, getClass().getEnclosingClass(), getTestSuiteSectionName(EXPECTED_NUMBER_OF_SECTIONS -2));
+
+        SectionEventManager.processEvent(standaloneTestClassConfig, executionStore);
+
+        int parentCount = 1 + EXPECTED_NUMBER_OF_SECTIONS * 2;
+        int treeNodesCount = (int) (parentCount + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 2));
+        assertThat(sections).hasSize(parentCount);
+
+        assertThatExecutionReport(executionStore.getExecutionReport())
+            .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class);
+
+        List<TestSuiteReport> testSuiteReports = executionStore.getExecutionReport().getTestSuiteReports();
+        TestSuiteReport testSuiteReport = testSuiteReports.get(testSuiteReports.size() - 2);
+        List<TestClassReport> testClassReports = testSuiteReport.getTestClassReports();
+        TestClassReport testClassReport = testClassReports.get(testClassReports.size() - 1);
+
+        assertThatReport(testClassReport.getConfiguration()).hasNumberOfSubReports(5);
+
+        Report testClassConfigReport = testClassReport.getConfiguration().getSubReports().get(4);
+        assertThat(testClassConfigReport).isEqualTo(configurationReport);
+
+        assertThatSectionTree(executionStore.getSectionTree())
+            .wholeTreeConsistOfCouplesMatching(sections)
+            .wholeTreeHasNumberOfTreeNodes(treeNodesCount)
+            .associatedReport();
+    }
 }

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/TestMethodSectionTreeEventManagerTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/TestMethodSectionTreeEventManagerTest.java
@@ -2,20 +2,25 @@ package org.arquillian.reporter.impl.section;
 
 import java.util.List;
 import java.util.Map;
-
 import org.arquillian.reporter.api.event.SectionEvent;
 import org.arquillian.reporter.api.event.TestClassSection;
+import org.arquillian.reporter.api.event.TestMethodConfigurationSection;
+import org.arquillian.reporter.api.event.TestMethodFailureSection;
 import org.arquillian.reporter.api.event.TestSuiteSection;
 import org.arquillian.reporter.api.model.report.ConfigurationReport;
 import org.arquillian.reporter.api.model.report.FailureReport;
+import org.arquillian.reporter.api.model.report.Report;
 import org.arquillian.reporter.api.model.report.TestClassReport;
 import org.arquillian.reporter.api.model.report.TestMethodReport;
 import org.arquillian.reporter.api.model.report.TestSuiteReport;
 import org.arquillian.reporter.impl.ExecutionSection;
 import org.arquillian.reporter.impl.ExecutionStore;
+import org.arquillian.reporter.impl.SectionEventManager;
+import org.arquillian.reporter.impl.utils.ReportGeneratorUtils;
 import org.junit.Test;
 
 import static org.arquillian.reporter.impl.asserts.ExecutionReportAssert.assertThatExecutionReport;
+import static org.arquillian.reporter.impl.asserts.ReportAssert.assertThatReport;
 import static org.arquillian.reporter.impl.asserts.SectionTreeAssert.assertThatSectionTree;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.EXPECTED_NUMBER_OF_SECTIONS;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestClassSections;
@@ -24,6 +29,8 @@ import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithT
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestMethodSections;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestSuiteSections;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.getSubsectionsOfSomeSection;
+import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.getTestMethodForSection;
+import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.getTestSuiteSectionName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -46,7 +53,7 @@ public class TestMethodSectionTreeEventManagerTest {
 
         assertThatExecutionReport(executionStore.getExecutionReport())
             .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class,
-                                                    TestMethodReport.class);
+                TestMethodReport.class);
 
         assertThatSectionTree(executionStore.getSectionTree())
             .wholeTreeConsistOfCouplesMatching(sections)
@@ -59,12 +66,12 @@ public class TestMethodSectionTreeEventManagerTest {
         ExecutionStore executionStore = new ExecutionStore();
         Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
         sections.putAll(feedWithTestClassSections(executionStore,
-                                                  getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
+            getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
         sections.putAll(feedWithTestMethodSections(executionStore,
-                                                   getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
+            getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
         sections.putAll(feedWithTestMethodConfigurationSections(executionStore,
-                                                                getSubsectionsOfSomeSection(TestClassSection.class,
-                                                                                            sections)));
+            getSubsectionsOfSomeSection(TestClassSection.class,
+                sections)));
 
         int parentCount = (int) (1 + (EXPECTED_NUMBER_OF_SECTIONS * 2) + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 2));
         int treeNodesCount = (int) (parentCount + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 3));
@@ -72,7 +79,7 @@ public class TestMethodSectionTreeEventManagerTest {
 
         assertThatExecutionReport(executionStore.getExecutionReport())
             .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class,
-                                                    TestMethodReport.class, ConfigurationReport.class);
+                TestMethodReport.class, ConfigurationReport.class);
 
         assertThatSectionTree(executionStore.getSectionTree())
             .wholeTreeConsistOfCouplesMatching(sections)
@@ -85,12 +92,12 @@ public class TestMethodSectionTreeEventManagerTest {
         ExecutionStore executionStore = new ExecutionStore();
         Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
         sections.putAll(feedWithTestClassSections(executionStore,
-                                                  getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
+            getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
         sections.putAll(feedWithTestMethodSections(executionStore,
-                                                   getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
+            getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
         sections.putAll(
             feedWithTestMethodFailureSections(executionStore,
-                                              getSubsectionsOfSomeSection(TestClassSection.class, sections)));
+                getSubsectionsOfSomeSection(TestClassSection.class, sections)));
 
         int parentCount = (int) (1 + (EXPECTED_NUMBER_OF_SECTIONS * 2) + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 2));
         int treeNodesCount = (int) (parentCount + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 3));
@@ -98,7 +105,102 @@ public class TestMethodSectionTreeEventManagerTest {
 
         assertThatExecutionReport(executionStore.getExecutionReport())
             .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class,
-                                                    TestMethodReport.class, FailureReport.class);
+                TestMethodReport.class, FailureReport.class);
+
+        assertThatSectionTree(executionStore.getSectionTree())
+            .wholeTreeConsistOfCouplesMatching(sections)
+            .wholeTreeHasNumberOfTreeNodes(treeNodesCount)
+            .associatedReport();
+    }
+
+    @Test
+    public void testAddingStandaloneTestMethodConfigurationSectionsWithReportsUsingEventManager() throws Exception {
+        ExecutionStore executionStore = new ExecutionStore();
+        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
+        sections.putAll(feedWithTestClassSections(executionStore,
+            getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
+        sections.putAll(feedWithTestMethodSections(executionStore,
+            getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
+        sections.putAll(feedWithTestMethodConfigurationSections(executionStore,
+            getSubsectionsOfSomeSection(TestClassSection.class,
+                sections)));
+
+        ConfigurationReport configurationReport =
+            ReportGeneratorUtils.prepareReport(ConfigurationReport.class, "Standalone config report", 0, 10);
+
+        TestMethodConfigurationSection standaloneMethodConfig =
+            TestMethodConfigurationSection.standalone(configurationReport,
+                getTestMethodForSection(EXPECTED_NUMBER_OF_SECTIONS - 2),
+                getTestSuiteSectionName(EXPECTED_NUMBER_OF_SECTIONS - 2));
+
+        SectionEventManager.processEvent(standaloneMethodConfig, executionStore);
+
+        int parentCount = (int) (1 + (EXPECTED_NUMBER_OF_SECTIONS * 2) + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 2));
+        int treeNodesCount = (int) (parentCount + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 3));
+        assertThat(sections).hasSize(parentCount);
+
+        assertThatExecutionReport(executionStore.getExecutionReport())
+            .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class,
+                TestMethodReport.class);
+
+        List<TestSuiteReport> testSuiteReports = executionStore.getExecutionReport().getTestSuiteReports();
+        TestSuiteReport testSuiteReport = testSuiteReports.get(testSuiteReports.size() - 2);
+        List<TestClassReport> testClassReports = testSuiteReport.getTestClassReports();
+        TestClassReport testClassReport = testClassReports.get(testClassReports.size() - 1);
+        List<TestMethodReport> testMethodReports = testClassReport.getTestMethodReports();
+        TestMethodReport testMethodReport = testMethodReports.get(testMethodReports.size() - 2);
+
+        assertThatReport(testMethodReport.getConfiguration()).hasNumberOfSubReports(5);
+
+        Report TestMethodConfigReport = testMethodReport.getConfiguration().getSubReports().get(4);
+        assertThat(TestMethodConfigReport).isEqualTo(configurationReport);
+
+        assertThatSectionTree(executionStore.getSectionTree())
+            .wholeTreeConsistOfCouplesMatching(sections)
+            .wholeTreeHasNumberOfTreeNodes(treeNodesCount)
+            .associatedReport();
+    }
+
+    @Test
+    public void testAddingStandaloneTestMethodFailureSectionsWithReportsUsingEventManager() throws Exception {
+        ExecutionStore executionStore = new ExecutionStore();
+        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
+        sections.putAll(feedWithTestClassSections(executionStore,
+            getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
+        sections.putAll(feedWithTestMethodSections(executionStore,
+            getSubsectionsOfSomeSection(TestSuiteSection.class, sections)));
+        sections.putAll(
+            feedWithTestMethodFailureSections(executionStore,
+                getSubsectionsOfSomeSection(TestClassSection.class, sections)));
+
+        FailureReport failureReport =
+            ReportGeneratorUtils.prepareReport(FailureReport.class, "Standalone failure report", 0, 10);
+
+        TestMethodFailureSection standaloneMethodFailure =
+            TestMethodFailureSection.standalone(failureReport, getTestMethodForSection(EXPECTED_NUMBER_OF_SECTIONS - 2),
+                getTestSuiteSectionName(EXPECTED_NUMBER_OF_SECTIONS - 2));
+
+        SectionEventManager.processEvent(standaloneMethodFailure, executionStore);
+
+        int parentCount = (int) (1 + (EXPECTED_NUMBER_OF_SECTIONS * 2) + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 2));
+        int treeNodesCount = (int) (parentCount + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 3));
+        assertThat(sections).hasSize(parentCount);
+
+        assertThatExecutionReport(executionStore.getExecutionReport())
+            .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, TestClassReport.class,
+                TestMethodReport.class);
+
+        List<TestSuiteReport> testSuiteReports = executionStore.getExecutionReport().getTestSuiteReports();
+        TestSuiteReport testSuiteReport = testSuiteReports.get(testSuiteReports.size() - 2);
+        List<TestClassReport> testClassReports = testSuiteReport.getTestClassReports();
+        TestClassReport testClassReport = testClassReports.get(testClassReports.size() - 1);
+        List<TestMethodReport> testMethodReports = testClassReport.getTestMethodReports();
+        TestMethodReport testMethodReport = testMethodReports.get(testMethodReports.size() - 2);
+
+        assertThatReport(testMethodReport.getFailureReport()).hasNumberOfSubReports(5);
+
+        Report testMethodFailureReport = testMethodReport.getFailureReport().getSubReports().get(4);
+        assertThat(testMethodFailureReport).isEqualTo(failureReport);
 
         assertThatSectionTree(executionStore.getSectionTree())
             .wholeTreeConsistOfCouplesMatching(sections)

--- a/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/TestSuiteSectionTreeEventManagerTest.java
+++ b/core/reporter-impl/src/test/java/org/arquillian/reporter/impl/section/TestSuiteSectionTreeEventManagerTest.java
@@ -4,18 +4,24 @@ import java.util.List;
 import java.util.Map;
 
 import org.arquillian.reporter.api.event.SectionEvent;
+import org.arquillian.reporter.api.event.TestSuiteConfigurationSection;
 import org.arquillian.reporter.api.model.report.ConfigurationReport;
+import org.arquillian.reporter.api.model.report.Report;
 import org.arquillian.reporter.api.model.report.TestSuiteReport;
 import org.arquillian.reporter.impl.ExecutionSection;
 import org.arquillian.reporter.impl.ExecutionStore;
+import org.arquillian.reporter.impl.SectionEventManager;
+import org.arquillian.reporter.impl.utils.ReportGeneratorUtils;
 import org.junit.Test;
 
 import static org.arquillian.reporter.impl.asserts.ExecutionReportAssert.assertThatExecutionReport;
+import static org.arquillian.reporter.impl.asserts.ReportAssert.assertThatReport;
 import static org.arquillian.reporter.impl.asserts.SectionTreeAssert.assertThatSectionTree;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.EXPECTED_NUMBER_OF_SECTIONS;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestSuiteConfigurationSections;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.feedWithTestSuiteSections;
 import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.getSubsectionsOfSomeSection;
+import static org.arquillian.reporter.impl.utils.SectionGeneratorUtils.getTestSuiteSectionName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -51,6 +57,42 @@ public class TestSuiteSectionTreeEventManagerTest {
         assertThat(sections).hasSize(parentCount);
         assertThatExecutionReport(executionStore.getExecutionReport())
             .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class, ConfigurationReport.class);
+
+        assertThatSectionTree(executionStore.getSectionTree())
+            .wholeTreeConsistOfCouplesMatching(sections)
+            .wholeTreeHasNumberOfTreeNodes(treeNodesCount)
+            .associatedReport();
+    }
+
+    @Test
+    public void testAddingStandaloneTestSuiteConfigurationSectionsWithReportsUsingEventManager() throws Exception {
+        ExecutionStore executionStore = new ExecutionStore();
+        Map<SectionEvent, List<? extends SectionEvent>> sections = feedWithTestSuiteSections(executionStore);
+        sections.putAll(
+            feedWithTestSuiteConfigurationSections(executionStore,
+                                                   getSubsectionsOfSomeSection(ExecutionSection.class, sections)));
+
+        ConfigurationReport configurationReport =
+            ReportGeneratorUtils.prepareReport(ConfigurationReport.class, "Standalone config report", 0, 10);
+
+
+        TestSuiteConfigurationSection standaloneSuiteConfig = TestSuiteConfigurationSection
+            .standalone(configurationReport, getTestSuiteSectionName(EXPECTED_NUMBER_OF_SECTIONS - 2));
+
+        SectionEventManager.processEvent(standaloneSuiteConfig, executionStore);
+
+        int parentCount = 1 + EXPECTED_NUMBER_OF_SECTIONS;
+        int treeNodesCount = (int) (parentCount + Math.pow(EXPECTED_NUMBER_OF_SECTIONS, 2));
+        assertThat(sections).hasSize(parentCount);
+        assertThatExecutionReport(executionStore.getExecutionReport())
+            .reportSubtreeConsistOfGeneratedReports(TestSuiteReport.class);
+
+        List<TestSuiteReport> testSuiteReports = executionStore.getExecutionReport().getTestSuiteReports();
+        TestSuiteReport testSuiteReport = testSuiteReports.get(testSuiteReports.size() - 2);
+        assertThatReport(testSuiteReport.getConfiguration()).hasNumberOfSubReports(5);
+
+        Report configReport = testSuiteReport.getConfiguration().getSubReports().get(4);
+        assertThat(configReport).isEqualTo(configurationReport);
 
         assertThatSectionTree(executionStore.getSectionTree())
             .wholeTreeConsistOfCouplesMatching(sections)


### PR DESCRIPTION
1. Verifies standalone reports are created and not merged.
2. Verifies section tree has no record for the event.